### PR TITLE
Rename Schema to DatasetSchema

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.tf.conftest import *  # noqa
 from tests.torch.conftest import *  # noqa
-from transformers4rec.utils.schema import Schema
+from transformers4rec.utils.schema import DatasetSchema
 
 ASSETS_DIR = pathlib.Path(__file__).parent / "assets"
 
@@ -34,4 +34,4 @@ def yoochoose_data_file():
 
 @pytest.fixture
 def yoochoose_schema():
-    return Schema.from_schema(str(YOOCHOOSE_SCHEMA))
+    return DatasetSchema.from_schema(str(YOOCHOOSE_SCHEMA))

--- a/tests/torch/conftest.py
+++ b/tests/torch/conftest.py
@@ -3,7 +3,7 @@ import random
 
 import pytest
 
-from transformers4rec.utils.schema import Schema
+from transformers4rec.utils.schema import DatasetSchema
 
 pytorch = pytest.importorskip("torch")
 np = pytest.importorskip("numpy")
@@ -118,7 +118,7 @@ def torch_yoochoose_like():
 
     schema_file = ASSETS_DIR / "yoochoose" / "schema.pbtxt"
 
-    schema = Schema.read_schema(str(schema_file))
+    schema = DatasetSchema.read_schema(str(schema_file))
     data = {}
 
     for i in range(NUM_ROWS):

--- a/tests/utils/test_schema.py
+++ b/tests/utils/test_schema.py
@@ -1,16 +1,16 @@
-from transformers4rec.utils.schema import Schema
+from transformers4rec.utils.schema import DatasetSchema
 from transformers4rec.utils.tags import Tag
 
 
 def test_schema_from_schema(schema_file):
-    schema = Schema.from_schema(str(schema_file))
+    schema = DatasetSchema.from_schema(str(schema_file))
 
     assert len(schema.columns) == 18
     assert schema.columns[1].tags == ["list"]
 
 
 def test_schema_from_yoochoose_schema(yoochoose_schema_file):
-    schema = Schema.from_schema(str(yoochoose_schema_file))
+    schema = DatasetSchema.from_schema(str(yoochoose_schema_file))
 
     assert len(schema.columns) == 20
     assert len(schema.select_by_tag(Tag.CONTINUOUS).columns) == 6

--- a/transformers4rec/meta_model_api/preprocess.py
+++ b/transformers4rec/meta_model_api/preprocess.py
@@ -14,17 +14,17 @@ from tqdm import tqdm
 
 
 def get_from_schema(self, to_get):
-    if isinstance(to_get, nvt.Schema):
+    if isinstance(to_get, nvt.DatasetSchema):
         to_get = set(to_get.columns)
     elif isinstance(to_get, str):
         to_get = {to_get}
     elif isinstance(to_get, collections.abc.Sequence):
         to_get = set(to_get)
     else:
-        raise ValueError(f"Expected Schema, str, or list of str. Got {to_get.__class__}")
+        raise ValueError(f"Expected DatasetSchema, str, or list of str. Got {to_get.__class__}")
 
     new_columns = [c for c in self.columns if c in to_get]
-    child = nvt.Schema(new_columns)
+    child = nvt.DatasetSchema(new_columns)
     child.parents = [self]
     self.children.append(child)
     child.kind = f"- {[c for c in self.columns if c not in to_get]}"

--- a/transformers4rec/tf/block/dlrm.py
+++ b/transformers4rec/tf/block/dlrm.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union
 
 import tensorflow as tf
 
-from ...types import Schema
+from ...types import DatasetSchema
 from ...utils.schema import Tag
 from .. import tabular
 from ..features.continuous import ContinuousFeatures
@@ -18,7 +18,7 @@ class ExpandDimsAndToTabular(tf.keras.layers.Lambda):
 class DLRMBlock(Block):
     def __init__(
         self,
-        continuous_features: Union[List[str], Schema, tabular.TabularLayer],
+        continuous_features: Union[List[str], DatasetSchema, tabular.TabularLayer],
         embedding_layer: EmbeddingFeatures,
         bottom_mlp: BlockType,
         top_mlp: Optional[BlockType] = None,
@@ -31,7 +31,7 @@ class DLRMBlock(Block):
     ):
         super().__init__(trainable, name, dtype, dynamic, **kwargs)
 
-        if isinstance(continuous_features, Schema):
+        if isinstance(continuous_features, DatasetSchema):
             continuous_features = ContinuousFeatures.from_schema(
                 continuous_features, aggregation="concat"
             )
@@ -59,7 +59,11 @@ class DLRMBlock(Block):
 
     @classmethod
     def from_schema(
-        cls, schema: Schema, bottom_mlp: BlockType, top_mlp: Optional[BlockType] = None, **kwargs
+        cls,
+        schema: DatasetSchema,
+        bottom_mlp: BlockType,
+        top_mlp: Optional[BlockType] = None,
+        **kwargs
     ):
         embedding_layer = EmbeddingFeatures.from_schema(
             schema.select_by_tag(Tag.CATEGORICAL),

--- a/transformers4rec/tf/data.py
+++ b/transformers4rec/tf/data.py
@@ -24,7 +24,7 @@ from nvtabular.loader.backend import DataLoader as BaseDataLoader
 from nvtabular.loader.tf_utils import configure_tensorflow, get_dataset_schema_from_feature_columns
 from nvtabular.ops import _get_embedding_order
 
-from ..utils.schema import Schema
+from ..utils.schema import DatasetSchema
 from ..utils.tags import Tag
 
 from_dlpack = configure_tensorflow()
@@ -277,7 +277,7 @@ class DataLoader(tf.keras.utils.Sequence, BaseDataLoader):
         if not os.path.exists(schema_path):
             raise ValueError("Can't load from directory without a schema.")
 
-        schema = Schema.from_schema(schema_path)
+        schema = DatasetSchema.from_schema(schema_path)
 
         categorical_features = (
             categorical_features or schema.select_by_tag(Tag.CATEGORICAL).column_names

--- a/transformers4rec/tf/features/embedding.py
+++ b/transformers4rec/tf/features/embedding.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from tensorflow.python.ops import init_ops_v2
 from tensorflow.python.tpu.tpu_embedding_v2_utils import FeatureConfig, TableConfig
 
-from ...types import Schema
+from ...types import DatasetSchema
 from ..tabular import AsSparseFeatures, FilterFeatures, TabularLayer
 
 # pylint has issues with TF array ops, so disable checks until fixed:
@@ -23,7 +23,7 @@ class EmbeddingFeatures(TabularLayer):
     @classmethod
     def from_schema(
         cls,
-        schema: Schema,
+        schema: DatasetSchema,
         embedding_dims=None,
         default_embedding_dim=64,
         infer_embedding_sizes=True,

--- a/transformers4rec/tf/features/tabular.py
+++ b/transformers4rec/tf/features/tabular.py
@@ -1,4 +1,4 @@
-from ...types import Schema, Tag
+from ...types import DatasetSchema, Tag
 from ..tabular import MergeTabular
 from .continuous import ContinuousFeatures
 from .embedding import EmbeddingFeatures
@@ -28,7 +28,7 @@ class TabularFeatures(MergeTabular):
     @classmethod
     def from_schema(
         cls,
-        schema: Schema,
+        schema: DatasetSchema,
         continuous_tags=Tag.CONTINUOUS,
         categorical_tags=Tag.CATEGORICAL,
         text_model=None,

--- a/transformers4rec/tf/head.py
+++ b/transformers4rec/tf/head.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Text
 
 import tensorflow as tf
 
-from ..types import Schema
+from ..types import DatasetSchema
 from ..utils.tags import Tag
 
 
@@ -139,7 +139,7 @@ class Head(tf.keras.layers.Layer):
         self._task_weights = defaultdict(lambda: 1)
 
     @classmethod
-    def from_schema(cls, schema: Schema, add_logits=True, task_weights=None):
+    def from_schema(cls, schema: DatasetSchema, add_logits=True, task_weights=None):
         if task_weights is None:
             task_weights = {}
         to_return = cls()

--- a/transformers4rec/tf/tabular.py
+++ b/transformers4rec/tf/tabular.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import tensorflow as tf
 
-from ..types import Schema
+from ..types import DatasetSchema
 from . import aggregation as agg
 from .utils.tf_utils import calculate_batch_size_from_input_shapes
 
@@ -128,7 +128,7 @@ class TabularLayer(tf.keras.layers.Layer):
         return calculate_batch_size_from_input_shapes(input_shapes)
 
     @classmethod
-    def from_schema(cls, schema: Schema, tags=None, **kwargs) -> Optional["TabularLayer"]:
+    def from_schema(cls, schema: DatasetSchema, tags=None, **kwargs) -> Optional["TabularLayer"]:
         if tags:
             schema = schema.select_by_tag(tags)
 

--- a/transformers4rec/torch/data.py
+++ b/transformers4rec/torch/data.py
@@ -22,7 +22,7 @@ from nvtabular.loader.backend import DataLoader as BaseDataLoader
 from nvtabular.loader.tensorflow import _validate_dataset
 from torch.utils.dlpack import from_dlpack
 
-from ..utils.schema import Schema
+from ..utils.schema import DatasetSchema
 from ..utils.tags import Tag
 from .utils.torch_utils import get_output_sizes_from_schema
 
@@ -140,7 +140,7 @@ class DataLoader(torch.utils.data.IterableDataset, BaseDataLoader):
         if not os.path.exists(schema_path):
             raise ValueError("Can't load from directory without a schema.")
 
-        schema = Schema.from_schema(schema_path)
+        schema = DatasetSchema.from_schema(schema_path)
 
         categorical_features = (
             categorical_features or schema.select_by_tag(Tag.CATEGORICAL).column_names

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -9,7 +9,7 @@ from transformers4rec.torch.utils.torch_utils import (
     get_output_sizes_from_schema,
 )
 
-from ...types import DefaultTags, Schema
+from ...types import DatasetSchema, DefaultTags
 from ..tabular import FilterFeatures, TabularModule
 
 
@@ -126,7 +126,7 @@ class EmbeddingFeatures(TabularModule):
     @classmethod
     def from_schema(
         cls,
-        schema: Schema,
+        schema: DatasetSchema,
         embedding_dims=None,
         default_embedding_dim=64,
         infer_embedding_sizes=False,

--- a/transformers4rec/torch/features/tabular.py
+++ b/transformers4rec/torch/features/tabular.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...types import Schema, Tag
+from ...types import DatasetSchema, Tag
 from ..block.mlp import MLPBlock
 from ..tabular import AsTabular, MergeTabular, TabularModule
 from ..utils.torch_utils import get_output_sizes_from_schema
@@ -46,7 +46,7 @@ class TabularFeatures(MergeTabular):
     @classmethod
     def from_schema(
         cls,
-        schema: Schema,
+        schema: DatasetSchema,
         continuous_tags=Tag.CONTINUOUS,
         categorical_tags=Tag.CATEGORICAL,
         aggregation=None,

--- a/transformers4rec/torch/head.py
+++ b/transformers4rec/torch/head.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Text, Union
 import torch
 import torchmetrics as tm
 
-from ..types import Schema
+from ..types import DatasetSchema
 from ..utils.tags import Tag
 from .features.embedding import EmbeddingFeatures
 from .tabular import MergeTabular
@@ -209,7 +209,9 @@ class Head(torch.nn.Module):
         self.input_size = input_size
 
     @classmethod
-    def from_schema(cls, schema: Schema, add_logits=True, task_weights=None, input_size=None):
+    def from_schema(
+        cls, schema: DatasetSchema, add_logits=True, task_weights=None, input_size=None
+    ):
         if task_weights is None:
             task_weights = {}
         to_return = cls(input_size=input_size)

--- a/transformers4rec/torch/tabular.py
+++ b/transformers4rec/torch/tabular.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import torch
 
-from ..types import Schema
+from ..types import DatasetSchema
 from . import aggregation as agg
 
 
@@ -111,7 +111,7 @@ class TabularModule(TabularMixin, torch.nn.Module):
             self._aggregation = None
 
     @classmethod
-    def from_schema(cls, schema: Schema, tags=None, **kwargs) -> Optional["TabularModule"]:
+    def from_schema(cls, schema: DatasetSchema, tags=None, **kwargs) -> Optional["TabularModule"]:
         if tags:
             schema = schema.select_by_tag(tags)
 

--- a/transformers4rec/types.py
+++ b/transformers4rec/types.py
@@ -1,8 +1,4 @@
-try:
-    from nvtabular import Schema
-    from nvtabular.tag import DefaultTags, Tag
-except ImportError:
-    from .utils.schema import Schema
-    from .utils.tags import DefaultTags, Tag
+from .utils.schema import DatasetSchema
+from .utils.tags import DefaultTags, Tag
 
-__all__ = ["Schema", "Tag", "DefaultTags"]
+__all__ = ["DatasetSchema", "Tag", "DefaultTags"]


### PR DESCRIPTION
Rename Schema to DatasetSchema to be consistent with NVTabular
https://github.com/NVIDIA/NVTabular/pull/1020 , and update
to remove the parent/child relationship which isn't used anymore.

Also remove the optional nvtabular dependency in types.py - we
currently rely on functionality that isn't in NVT yet (reading from
metadata protofile, tags etc).