### PR TITLE
Fix cloudpickle load error

### DIFF
--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -578,9 +578,7 @@ class Trainer(BaseTrainer):
             except ImportError:
                 raise ImportError("cloudpickle is required to load model class")
             logger.info("Loading model class")
-            self.model = cloudpickle.load(
-                open(os.path.join(checkpoint_path, "model_class.pkl"), "rb")
-            )
+            model = cloudpickle.load(open(os.path.join(checkpoint_path, "model_class.pkl"), "rb"))
 
         self.model = HFWrapper(model)
         logger.info("Loading weights of previously trained model")


### PR DESCRIPTION
This fixes the error yields from `trainer.load_model_trainer_states_from_checkpoint('./checkpoint-%s'%trainer.state.global_step)`