### PR TITLE
Add conda recipe

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -28,6 +28,6 @@ requirements:
     {% endfor %}
 
 about:
-  home: https://github.com/nvidia-merlin/transformers4Rec/
+  home: https://github.com/NVIDIA-Merlin/Transformers4Rec
   license_file: LICENSE
   summary: Transformers4Rec is a flexible and efficient library for sequential and session-based recommendation, available for both PyTorch and Tensorflow.

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ requirements = {
 
 setup(
     name="transformers4rec",
-    version="0.01",
+    version="0.1",
     packages=find_packages(),
-    url="https://github.com/nvidia-merlin/transformers4Rec/",
+    url="https://github.com/NVIDIA-Merlin/Transformers4Rec",
     author="NVIDIA Corporation",
     license="Apache 2.0",
     long_description=open("README.md", encoding="utf8").read(),


### PR DESCRIPTION
This adds a basic conda recipe for publishing to anaconda, picking up dependencies from the
base 'install_requires' section of setup.py.

This also fixes a minor error in the 'read_requirements' in setup.py: requirements
from multiple lines were being returned as a single list entry.