### PR TITLE
Minor doc fixes

### DIFF
--- a/transformers4rec/config/trainer.py
+++ b/transformers4rec/config/trainer.py
@@ -25,25 +25,20 @@ class T4RecTrainingArguments(TrainingArguments):
     Class that inherits HF TrainingArguments and add on top of it arguments needed for
     session-based and sequential-based recommendation
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     avg_session_length : int
         the avg. session length (rounded up to the next int),
         It is used to estimate the number of interactions from the batch_size (# sessions)
         so that the tensor that accumulates all predictions is sufficient
         to concatenate all predictions
-
-    shuffle_buffer_size
-
+    shuffle_buffer_size:
     validate_every: Optional[int], int
         Run validation set every this epoch.
         -1 means no validation is used
         by default -1
-
-    eval_on_test_set
-
-    eval_steps_on_train_set
-
+    eval_on_test_set:
+    eval_steps_on_train_set:
     predict_top_k:  Option[int], int
         Truncate recommendation list to the highest top-K predicted items
         (do not affect evaluation metrics computation)

--- a/transformers4rec/tf/masking.py
+++ b/transformers4rec/tf/masking.py
@@ -42,7 +42,6 @@ MASK_SEQUENCE_PARAMETERS_DOCSTRING = """
 @docstring_parameter(mask_sequence_parameters=MASK_SEQUENCE_PARAMETERS_DOCSTRING)
 class MaskSequence(tf.keras.layers.Layer):
     """Base class to prepare masked items inputs/labels for language modeling tasks.
-    Parameters
 
     Transformer architectures can be trained in different ways. Depending of the training method,
     there is a specific masking schema. The masking schema sets the items to be predicted (labels)
@@ -57,6 +56,7 @@ class MaskSequence(tf.keras.layers.Layer):
 
     This class can be extended to add different a masking scheme.
 
+    Parameters
     ----------
     {mask_sequence_parameters}
     """
@@ -207,7 +207,7 @@ class CausalLanguageModeling(MaskSequence):
     In Causal Language Modeling (clm) you predict the next item based on past positions of the
     sequence. Future positions are masked.
 
-    Parameters:
+    Parameters
     ----------
     {mask_sequence_parameters}
     train_on_last_item_seq_only: predict only last item during training
@@ -277,8 +277,8 @@ class MaskedLanguageModeling(MaskSequence):
     During inference, all past items are visible for the Transformer layer, which tries to predict
     the next item.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     {mask_sequence_parameters}
     mlm_probability: Optional[float], default = 0.15
         Probability of an item to be selected (masked) as a label of the given sequence.
@@ -305,8 +305,8 @@ class MaskedLanguageModeling(MaskSequence):
         Prepare sequence with mask schema for masked language modeling prediction
         the function is based on HuggingFace's transformers/data/data_collator.py
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         item_ids: tf.Tensor
             Sequence of input itemid (target) column
 

--- a/transformers4rec/tf/tabular/tabular.py
+++ b/transformers4rec/tf/tabular/tabular.py
@@ -167,7 +167,7 @@ class TabularBlock(Block):
         return cls.from_features(_schema.column_names, schema=_schema, **kwargs)
 
     @classmethod
-    @docstring_parameter(tabular_module_parameters=TABULAR_MODULE_PARAMS_DOCSTRING)
+    @docstring_parameter(tabular_module_parameters=TABULAR_MODULE_PARAMS_DOCSTRING, extra_padding=4)
     def from_features(
         cls,
         features: List[str],
@@ -177,8 +177,8 @@ class TabularBlock(Block):
         name=None,
         **kwargs
     ) -> "TabularBlock":
-        """Initializes a TabularLayer instance where the contents of features will be filtered
-            out
+        """
+        Initializes a TabularLayer instance where the contents of features will be filtered out
 
         Parameters
         ----------

--- a/transformers4rec/torch/masking.py
+++ b/transformers4rec/torch/masking.py
@@ -41,7 +41,6 @@ MASK_SEQUENCE_PARAMETERS_DOCSTRING = """
 @docstring_parameter(mask_sequence_parameters=MASK_SEQUENCE_PARAMETERS_DOCSTRING)
 class MaskSequence(OutputSizeMixin, torch.nn.Module):
     """Base class to prepare masked items inputs/labels for language modeling tasks.
-    Parameters
 
     Transformer architectures can be trained in different ways. Depending of the training method,
     there is a specific masking schema. The masking schema sets the items to be predicted (labels)
@@ -56,6 +55,7 @@ class MaskSequence(OutputSizeMixin, torch.nn.Module):
 
     This class can be extended to add different a masking scheme.
 
+    Parameters
     ----------
     hidden_size:
         The hidden dimension of input tensors, needed to initialize trainable vector of
@@ -220,7 +220,7 @@ class CausalLanguageModeling(MaskSequence):
     In Causal Language Modeling (clm) you predict the next item based on past positions of the
     sequence. Future positions are masked.
 
-    Parameters:
+    Parameters
     ----------
     {mask_sequence_parameters}
     train_on_last_item_seq_only: predict only last item during training
@@ -292,8 +292,8 @@ class MaskedLanguageModeling(MaskSequence):
     During inference, all past items are visible for the Transformer layer, which tries to predict
     the next item.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     {mask_sequence_parameters}
     mlm_probability: Optional[float], default = 0.15
         Probability of an item to be selected (masked) as a label of the given sequence.
@@ -322,8 +322,8 @@ class MaskedLanguageModeling(MaskSequence):
         Prepare sequence with mask schema for masked language modeling prediction
         the function is based on HuggingFace's transformers/data/data_collator.py
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         item_ids: torch.Tensor
             Sequence of input itemid (target) column
 
@@ -396,7 +396,7 @@ class PermutationLanguageModeling(MaskSequence):
     In Permutation Language Modeling (plm) you use a permutation factorization at the level of the
     self-attention layer to define the accessible bidirectional context.
 
-    Parameters:
+    Parameters
     ----------
     {mask_sequence_parameters}
     max_span_length: int
@@ -440,8 +440,8 @@ class PermutationLanguageModeling(MaskSequence):
         Prepare the attention masks needed for permutation language modeling
         The function is based on HuggingFace's transformers/data/data_collator.py
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         item_ids: torch.Tensor
             Sequence of input itemid (target) column.
 
@@ -619,7 +619,7 @@ class ReplacementLanguageModeling(MaskedLanguageModeling):
     to classify whether the item at each position belongs or not to the original sequence.
     The generator-discriminator architecture was jointly trained using Masked LM and RTD tasks.
 
-    Parameters:
+    Parameters
     ----------
     {mask_sequence_parameters}
     sample_from_batch: bool

--- a/transformers4rec/torch/model/head.py
+++ b/transformers4rec/torch/model/head.py
@@ -258,7 +258,7 @@ class RegressionTask(PredictionTask):
 class NextItemPredictionTask(PredictionTask):
     """Next-item prediction task.
 
-    Parameters:
+    Parameters
     ----------
     loss: torch.nn.Module
         Loss function to use. Defaults to NLLLos.
@@ -469,8 +469,8 @@ class _NextItemPredictionTask(torch.nn.Module):
     - During training, the class supports the following Language modeling tasks:
         Causal LM, Masked LM, Permutation LM and Replacement Token Detection
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
         input_size: int
             Input size of this module.
         target_dim: int

--- a/transformers4rec/torch/tabular/tabular.py
+++ b/transformers4rec/torch/tabular/tabular.py
@@ -135,7 +135,7 @@ class TabularModule(torch.nn.Module):
         return cls.from_features(_schema.column_names, schema=_schema, **kwargs)
 
     @classmethod
-    @docstring_parameter(tabular_module_parameters=TABULAR_MODULE_PARAMS_DOCSTRING)
+    @docstring_parameter(tabular_module_parameters=TABULAR_MODULE_PARAMS_DOCSTRING, extra_padding=4)
     def from_features(
         cls,
         features: List[str],

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -51,6 +51,32 @@ class Trainer(BaseTrainer):
     """
     An :class:`~transformers.Trainer` specialized for sequential recommendation
     including (session-based and sequtial recommendation)
+
+    Parameters
+    ----------
+    model: Model
+        The Model defined using Transformers4Rec api.
+    args: T4RecTrainingArguments
+        The training arguments needed to setup training and evaluation
+        experiments.
+    schema: Optional[Dataset.schema], optional
+        The schema object including features to use and their properties.
+        by default None
+    train_dataset_or_path: Optional[Union[str, Dataset]], optional
+        Path of parquet files or DataSet to use for training.
+        by default None
+    eval_dataset_or_path: Optional[str, Dataset], optional
+        Path of parquet files or DataSet to use for evaluation.
+        by default None
+    train_dataloader: Optional[DataLoader], optional
+        The data generator to use for training.
+        by default None
+    eval_dataloader: Optional[DataLoader], optional
+        The data generator to use for evaluation.
+        by default None
+    compute_metrics: Optional[bool], optional
+        Whether to compute metrics defined by Model class or not.
+        by default None
     """
 
     def __init__(
@@ -65,33 +91,6 @@ class Trainer(BaseTrainer):
         compute_metrics=None,
         **kwargs,
     ):
-        """
-        Parameters:
-        -----------
-            model: Model,
-                The Model defined using Transformers4Rec api.
-            args: T4RecTrainingArguments,
-                The training arguments needed to setup training and evaluation
-                experiments.
-            schema: Optional[Dataset.schema], optional
-                The schema object including features to use and their properties.
-                by default None
-            train_dataset_or_path: Optional[Union[str, Dataset]], optional
-                Path of parquet files or DataSet to use for training.
-                by default None
-            eval_dataset_or_path: Optional[str, Dataset], optional
-                Path of parquet files or DataSet to use for evaluation.
-                by default None
-            train_dataloader: Optional[DataLoader], optional
-                The data generator to use for training.
-                by default None
-            eval_dataloader: Optional[DataLoader], optional
-                The data generator to use for evaluation.
-                by default None
-            compute_metrics: Optional[bool], optional
-                Whether to compute metrics defined by Model class or not.
-                by default None
-        """
 
         mock_dataset = DatasetMock()
         hf_model = HFWrapper(model)
@@ -206,22 +205,24 @@ class Trainer(BaseTrainer):
     ):
         """
         Unified API to get any scheduler from its name.
-        Args:
-            name (:obj:`str` or `:obj:`SchedulerType`):
-                The name of the scheduler to use.
-            optimizer (:obj:`torch.optim.Optimizer`):
-                The optimizer that will be used during training.
-            num_warmup_steps (:obj:`int`, `optional`):
-                The number of warmup steps to do. This is not required by all schedulers
-                (hence the argument being optional),
-                the function will raise an error if it's unset and the scheduler type requires it.
-            num_training_steps (:obj:`int`, `optional`):
-                The number of training steps to do. This is not required by all schedulers
-                (hence the argument being optional),
-                the function will raise an error if it's unset and the scheduler type requires it.
-            num_cycles: (:obj:`int`, `optional`):
-                The number of waves in the cosine schedule /
-                hard restarts to use for cosine scheduler
+
+        Parameters
+        ----------
+        name: (:obj:`str` or `:obj:`SchedulerType`)
+            The name of the scheduler to use.
+        optimizer: (:obj:`torch.optim.Optimizer`)
+            The optimizer that will be used during training.
+        num_warmup_steps: (:obj:`int`, `optional`)
+            The number of warmup steps to do. This is not required by all schedulers
+            (hence the argument being optional),
+            the function will raise an error if it's unset and the scheduler type requires it.
+        num_training_steps: (:obj:`int`, `optional`)
+            The number of training steps to do. This is not required by all schedulers
+            (hence the argument being optional),
+            the function will raise an error if it's unset and the scheduler type requires it.
+        num_cycles: (:obj:`int`, `optional`)
+            The number of waves in the cosine schedule /
+            hard restarts to use for cosine scheduler
         """
         name = SchedulerType(name)
         schedule_func = TYPE_TO_SCHEDULER_FUNCTION[name]
@@ -310,8 +311,8 @@ class Trainer(BaseTrainer):
         to log with the outputs of the model
         (e.g. prediction scores, prediction metadata, attention weights)
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         dataloader: DataLoader
             DataLoader object to use to iterate over evaluation data
         description: str
@@ -543,7 +544,7 @@ class Trainer(BaseTrainer):
         """
         Save the serialized model + trainer and random states.
 
-        Parameters:
+        Parameters
         ----------
         save_model_class: Optioanl[bool]
             Wether to save the Model class or not.
@@ -579,12 +580,12 @@ class Trainer(BaseTrainer):
         It does not loads the optimizer and LR scheduler states (for that call trainer.train()
         with resume_from_checkpoint argument for a complete load)
 
-        Parameters:
+        Parameters
         ----------
-            checkpoint_path: str
-                Path to the checkpoint directory.
-            model: Optional[Model]
-                Model class used by Trainer. by default None
+        checkpoint_path: str
+            Path to the checkpoint directory.
+        model: Optional[Model]
+            Model class used by Trainer. by default None
         """
         import os
 
@@ -633,23 +634,23 @@ class Trainer(BaseTrainer):
         """
         If --log_predictions is enabled, calls a callback function to
         log predicted item ids, scores, metadata and metrics.
-        Parameters:
+        Parameters
         ----------
-            labels: torch.Tensor
-                True labels.
-            pred_item_ids: torch.Tensor
-                The predicted items ids. if top_k is set:
-                we return to top-k items for each
-                next-item prediction.
-            pred_item_scores: torch.Tensor
-                The prediction scores, if top_k is set:
-                we return to top-k predictions for each
-                next-item prediction.
-            metrics: Dict[str, np.ndarray]
-                Dictionary of metrics computed by Model.
-            metric_key_prefix: str
-                Prefix to use when logging evaluation metrics.
-                by default `eval`
+        labels: torch.Tensor
+            True labels.
+        pred_item_ids: torch.Tensor
+            The predicted items ids. if top_k is set:
+            we return to top-k items for each
+            next-item prediction.
+        pred_item_scores: torch.Tensor
+            The prediction scores, if top_k is set:
+            we return to top-k predictions for each
+            next-item prediction.
+        metrics: Dict[str, np.ndarray]
+            Dictionary of metrics computed by Model.
+        metric_key_prefix: str
+            Prefix to use when logging evaluation metrics.
+            by default `eval`
         """
         # TODO Add pred_metadata: Dict[str, torch.Tensor],
 

--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -97,10 +97,11 @@ if dependencies.is_pyarrow_available():
         def set_dataset(self, cols_to_read):
             """
             set the Parquet dataset
-            Args:
-            ------
-                cols_to_read: str
-                    The list of features names to load
+
+            Parameters
+            ----------
+            cols_to_read: str
+                The list of features names to load
             """
 
             if isinstance(self.paths_or_dataset, ParquetDataset):
@@ -132,17 +133,18 @@ if dependencies.is_pyarrow_available():
             **kwargs,
         ):
             """
-               Instantitates ``PyarrowDataLoader`` from a ``DatasetSchema``.
+            Instantiates ``PyarrowDataLoader`` from a ``DatasetSchema``.
+
             Parameters
             ----------
-                schema: DatasetSchema
-                    Dataset schema
-                paths_or_dataset: Union[str, Dataset]
-                    Path to paquet data of Dataset object.
-                batch_size: int
-                    batch size of Dataloader.
-                max_sequence_length: int
-                    The maximum length of list features.
+            schema: DatasetSchema
+                Dataset schema
+            paths_or_dataset: Union[str, Dataset]
+                Path to paquet data of Dataset object.
+            batch_size: int
+                batch size of Dataloader.
+            max_sequence_length: int
+                The maximum length of list features.
             """
 
             categorical_features = (

--- a/transformers4rec/utils/gpu_preprocessing.py
+++ b/transformers4rec/utils/gpu_preprocessing.py
@@ -34,22 +34,22 @@ def save_time_based_splits(
     Note, this function requires Rapids dependencies to be installed:
     cudf, cupy and dask_cudf
 
-    Parameters:
+    Parameters
     -----
-        data: Union[nvtabular.Dataset, dask_cudf.DataFrame]
-            Dataset to split into time-based splits.
-        output_dir: str
-            Output path the save the time-based splits.
-        partition_col: str
-            Time-column to partition the data on.
-        timestamp_col: str
-            Timestamp column to use to sort each split.
-        test_size: float
-            Size of the test split, needs to be a number between 0.0 & 1.0.
-        val_size: float
-            Size of the validation split, needs to be a number between 0.0 & 1.0.
-        overwrite: bool
-            Whether or not to overwrite the output_dir if it already exists.
+    data: Union[nvtabular.Dataset, dask_cudf.DataFrame]
+        Dataset to split into time-based splits.
+    output_dir: str
+        Output path the save the time-based splits.
+    partition_col: str
+        Time-column to partition the data on.
+    timestamp_col: str
+        Timestamp column to use to sort each split.
+    test_size: float
+        Size of the test split, needs to be a number between 0.0 & 1.0.
+    val_size: float
+        Size of the validation split, needs to be a number between 0.0 & 1.0.
+    overwrite: bool
+        Whether or not to overwrite the output_dir if it already exists.
     """
 
     try:

--- a/transformers4rec/utils/misc_utils.py
+++ b/transformers4rec/utils/misc_utils.py
@@ -25,8 +25,16 @@ from typing import Any, Dict
 logger = logging.getLogger(__name__)
 
 
-def docstring_parameter(*args, **kwargs):
+def docstring_parameter(*args, extra_padding=None, **kwargs):
     def dec(obj):
+        if extra_padding:
+
+            def pad(value):
+                return ("\n" + " " * extra_padding).join(value.split("\n"))
+
+            nonlocal args, kwargs
+            kwargs = {key: pad(value) for key, value in kwargs.items()}
+            args = [pad(value) for value in args]
         obj.__doc__ = obj.__doc__.format(*args, **kwargs)
         return obj
 
@@ -187,21 +195,21 @@ def _validate_dataset(paths_or_dataset, batch_size, buffer_size, engine, reader_
     """
     Util function to load NVTabular Dataset from disk
 
-    Parameters:
+    Parameters
     ----------
-        paths_or_dataset: Union[nvtabular.Dataset, str]
-            Path  to dataset to load of nvtabular Dataset,
-            if Dataset, return the object.
-        batch_size: int
-            batch size for Dataloader.
-        buffer_size: float
-            parameter, which refers to the fraction of batches
-            to load at once.
-        engine: str
-            parameter to specify the file format,
-            possible values are: ["parquet", "csv", "csv-no-header"].
-        reader_kwargs: dict
-            Additional arguments of the specified reader.
+    paths_or_dataset: Union[nvtabular.Dataset, str]
+        Path  to dataset to load of nvtabular Dataset,
+        if Dataset, return the object.
+    batch_size: int
+        batch size for Dataloader.
+    buffer_size: float
+        parameter, which refers to the fraction of batches
+        to load at once.
+    engine: str
+        parameter to specify the file format,
+        possible values are: ["parquet", "csv", "csv-no-header"].
+    reader_kwargs: dict
+        Additional arguments of the specified reader.
     """
     try:
         from nvtabular.io.dataset import Dataset


### PR DESCRIPTION
* add a 'extra_padding' argument to docstring_parameters, so that we can handle parameters that
 need varying amounts of padding (for instance when used on a class vs a method of that class),
 and then use to fix some issues with TABULAR_MODULE_PARAMS_DOCSTRING around from_features methods
* Fix warnings around invalid section titles (using Args instead of Parameters etc)