### PR TITLE
Provide minimum versions of our dependencies

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, NVIDIA CORPORATION.
 
 # Usage:
-#   conda build . -c defaults -c conda-forge
+#   conda build . -c defaults -c conda-forge -c huggingface -c anaconda
 
 {% set setup_py_data = load_setup_py_data() %}
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-numpy
+numpy>=1.17.0
 tensorflow-metadata
-transformers
-tqdm
+transformers==4.9.*
+tqdm>=4.27
 pyarrow>=1.0

--- a/requirements/pytorch.txt
+++ b/requirements/pytorch.txt
@@ -1,2 +1,2 @@
-torch
-torchmetrics
+torch>=1.0
+torchmetrics==0.3.2

--- a/requirements/tensorflow.txt
+++ b/requirements/tensorflow.txt
@@ -1,1 +1,1 @@
-tensorflow
+tensorflow>=2.3


### PR DESCRIPTION
Add minimum versions of most of our dependencies, with the goal of reducing
the time it takes to build our conda package (which is over 3 hours right now).

Also pin torchmetrics to 0.3.2 to work around https://github.com/PyTorchLightning/metrics/issues/507