### PR TITLE
Test eval mode of Model class

### DIFF
--- a/transformers4rec/tf/masking.py
+++ b/transformers4rec/tf/masking.py
@@ -370,7 +370,11 @@ class MaskedLanguageModeling(MaskSequence):
                 last_item_sessions = tf.reduce_sum(non_padded_mask, axis=1) - 1
 
                 indices = tf.concat(
-                    [tf.expand_dims(rows_ids, 1), tf.expand_dims(last_item_sessions, 1)], axis=1
+                    [
+                        tf.expand_dims(rows_ids, 1),
+                        tf.cast(tf.expand_dims(last_item_sessions, 1), tf.int64),
+                    ],
+                    axis=1,
                 )
                 labels = tf.tensor_scatter_nd_update(
                     labels, indices=indices, updates=tf.gather_nd(item_ids, indices)

--- a/transformers4rec/tf/model/model.py
+++ b/transformers4rec/tf/model/model.py
@@ -86,7 +86,8 @@ class Model(BaseModel):
         # TODO: Optimize this
         outputs = {}
         for head in self.heads:
-            outputs.update(head(inputs, call_body=True, always_output_dict=True))
+            body_outputs = head.body(inputs)
+            outputs.update(head(body_outputs, call_body=False, always_output_dict=True))
 
         if len(outputs) == 1:
             return outputs[list(outputs.keys())[0]]


### PR DESCRIPTION
- This PR add a unit test to make sure that the Model class is correctly working in eval mode, particularly checking if the masking task is set with `training=False`.
- It also includes minor fix related to calling the body of the Head within Model class. Otherwise the `build` method of the NextItemPredictionTask is raising an error (getting the `input_shape` from the input module as a dict of shapes while the task is expecting the input shape from the body output as 3-dim vector). 

closes #235 