### PR TITLE
Include package data when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     install_requires=requirements["base"],
     test_suite="tests",
     extras_require={**requirements, "all": list(itertools.chain(*list(requirements.values())))},
+    include_package_data=True,
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Currently we bundle JSON and Parquet files in our MANIFEST, but these don't
get installed with the source files. This causes issues when importing
transformers4rec.data because some test json schema files are missing:

```
value /opt/conda/lib/python3.8/site-packages/transformers4rec/data/testing/schema.json
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/lib/python3.8/site-packages/transformers4rec/data/__init__.py", line 18, in <module>
    from .testing.dataset import tabular_sequence_testing_data
  File "/opt/conda/lib/python3.8/site-packages/transformers4rec/data/testing/dataset.py", line 22, in <module>
    tabular_sequence_testing_data: ParquetDataset = ParquetDataset(pathlib.Path(__file__).parent)
  File "/opt/conda/lib/python3.8/site-packages/transformers4rec/data/dataset.py", line 65, in __init__
    super(ParquetDataset, self).__init__(schema_path or os.path.join(dir, schema_file_name))
  File "/opt/conda/lib/python3.8/site-packages/transformers4rec/data/dataset.py", line 30, in __init__
    self._schema = Schema().from_json(self.schema_path)
  File "/opt/conda/lib/python3.8/site-packages/merlin_standard_lib/schema/schema.py", line 395, in from_json
    return super().from_json(value)
  File "/opt/conda/lib/python3.8/site-packages/betterproto/__init__.py", line 916, in from_json
    return self.from_dict(json.loads(value))
  File "/opt/conda/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/opt/conda/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/opt/conda/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Fix by including ```include_package_data=True``` in the setup.py file to force installing
these files.
