### PR TITLE
Quick fix of  compute_loss to be able to use fit method in tensorflow  

### DIFF
--- a/tests/tf/model/test_head.py
+++ b/tests/tf/model/test_head.py
@@ -125,8 +125,6 @@ def test_item_prediction_loss_and_metrics(
 
     body_outputs = body(tf_yoochoose_like)
 
-    outputs = head(body_outputs)
-
     loss = head.compute_loss(body_outputs=body_outputs, targets=None)
 
     metrics = head.metric_results()
@@ -140,7 +138,6 @@ def test_item_prediction_loss_and_metrics(
         "recall_at_20",
     ]
     assert set(default_metric).issubset(set(metrics.keys()))
-    assert outputs.shape[-1] == 51997
     assert loss != 0
 
 

--- a/tests/tf/model/test_model.py
+++ b/tests/tf/model/test_model.py
@@ -100,3 +100,37 @@ def test_output_shape_mode_eval(tf_yoochoose_like, yoochoose_schema, masking):
 
     out = model(tf_yoochoose_like, training=False)
     assert out.shape[0] == tf_yoochoose_like["item_id/list"].shape[0]
+
+
+@pytest.mark.parametrize("masking", ["causal", "mlm"])
+def test_next_item_fit(tf_yoochoose_like, yoochoose_schema, masking, run_eagerly=True):
+
+    input_module = tr.TabularSequenceFeatures.from_schema(
+        yoochoose_schema,
+        max_sequence_length=20,
+        continuous_projection=64,
+        d_output=64,
+        masking=masking,
+    )
+
+    transformer_config = tr.XLNetConfig.build(d_model=64, n_head=8, n_layer=2, total_seq_length=20)
+    body = tr.SequentialBlock(
+        [
+            input_module,
+            tr.TransformerBlock(transformer_config, masking=input_module.masking),
+        ]
+    )
+    task = tr.NextItemPredictionTask(weight_tying=True)
+    model = task.to_model(body=body)
+    model.compile(optimizer="adam", run_eagerly=run_eagerly)
+
+    dataset = tf.data.Dataset.from_tensor_slices(
+        (tf_yoochoose_like, tf_yoochoose_like["item_id/list"])
+    ).batch(50)
+
+    losses = model.fit(dataset, epochs=5)
+    metrics = model.evaluate(tf_yoochoose_like, tf_yoochoose_like["item_id/list"], return_dict=True)
+
+    assert len(metrics.keys()) == 6
+    assert len(losses.epoch) == 5
+    assert all(loss >= 0 for loss in losses.history["loss"])

--- a/transformers4rec/tf/model/base.py
+++ b/transformers4rec/tf/model/base.py
@@ -132,14 +132,16 @@ class PredictionTask(Layer, LossMixin, MetricsMixin):
         inputs,
         targets,
         training: bool = False,
+        call_task: bool = True,
         compute_metrics=True,
         sample_weight: Optional[tf.Tensor] = None,
         **kwargs,
     ) -> tf.Tensor:
         if isinstance(targets, dict) and self.target_name:
             targets = targets[self.target_name]
-
-        predictions = self(inputs, training=training, **kwargs)
+        predictions = inputs
+        if call_task:
+            predictions = self(inputs, training=training, **kwargs)
         loss = self.loss(y_true=targets, y_pred=predictions, sample_weight=sample_weight)
 
         if compute_metrics:
@@ -389,8 +391,11 @@ class Head(tf.keras.layers.Layer):
         if call_body:
             body_outputs = self.body(body_outputs)
 
+        predictions = self(body_outputs, always_output_dict=True)
         for name, task in self.prediction_task_dict.items():
-            loss = task.compute_loss(body_outputs, targets, training=training, **kwargs)
+            loss = task.compute_loss(
+                predictions[name], targets, call_task=False, training=training, **kwargs
+            )
             losses.append(loss * self._task_weight_dict[name])
 
         return self.loss_reduction(losses)

--- a/transformers4rec/tf/model/prediction_task.py
+++ b/transformers4rec/tf/model/prediction_task.py
@@ -217,14 +217,16 @@ class NextItemPredictionTask(PredictionTask):
         self,
         inputs,
         targets=None,
-        compute_metrics=True,
+        compute_metrics: bool = True,
+        call_task: bool = True,
         sample_weight: Optional[tf.Tensor] = None,
         **kwargs,
     ) -> tf.Tensor:
         if isinstance(targets, dict) and self.target_name:
             targets = targets[self.target_name]
-
-        predictions = self(inputs)
+        predictions = inputs
+        if call_task:
+            predictions = self(inputs)
         # retrieve labels from masking
         if self.masking:
             targets = self.masking.masked_targets


### PR DESCRIPTION
### Goals :soccer:

The current implementation of compute_loss does not use the call methods of the `Head` and `Model` classes. This raises an issue for NextItemPredictionTask as the build method requires `body` to retrieve necessary information about items embeddings and masking. This class is only accessed via the build method of `Head`. 


<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:

The current PR presents a quick fix by exposing an argument `call_task` in the `compute_loss` of `PredictionTask` classes. The compute_loss methods of Head / Model are first computing the predictions through their __call__ methods (to correctly build the related tasks), then computing the tasks losses with `call_task=False`.


<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
This PR adds a test in test_model.py that defines a model with NextItemPredictionTask head, call the `fit` and `evaluate` methods, then check that losses and metrics are correctly computed.  
