### PR TITLE
[WIP] Define getting-started example notebook using TensorFlow & Add support of graph-mode

### DIFF
--- a/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
+++ b/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
@@ -3,6 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "1e9c3d21",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Copyright 2021 NVIDIA Corporation. All Rights Reserved.\n",
     "#\n",
@@ -18,45 +21,49 @@
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License.\n",
     "# =============================================================================="
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1f2cbdc7",
+   "metadata": {},
    "source": [
     "# Session-based Recommendation with XLNET"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "dafd844a",
+   "metadata": {},
    "source": [
     "In this notebook we introduce the [Transformers4Rec](https://github.com/NVIDIA-Merlin/Transformers4Rec) library for sequential and session-based recommendation. This notebook uses the PyTorch API, but a TensorFlow API is also available. Transformers4Rec integrates with the popular [HuggingFace’s Transformers](https://github.com/huggingface/transformers) and make it possible to experiment with cutting-edge implementation of the latest NLP Transformer architectures.  \n",
     "\n",
     "We demonstrate how to build a session-based recommendation model with the [XLNET](https://arxiv.org/abs/1906.08237) Transformer architecture. The XLNet architecture was designed to leverage the best of both auto-regressive language modeling and auto-encoding with its Permutation Language Modeling training method. In this example we will use XLNET with masked language modeling (MLM) training method, which showed very promising results in the experiments conducted in our [ACM RecSys'21 paper](https://github.com/NVIDIA-Merlin/publications/blob/main/2021_acm_recsys_transformers4rec/recsys21_transformers4rec_paper.pdf)."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8dc73b17",
+   "metadata": {},
    "source": [
     "In the previous notebook we went through our ETL pipeline with NVTabular library, and created sequential features to be used in training a session-based recommendation model. In this notebook we will learn:\n",
     "\n",
     "- Accelerating data loading of parquet files with multiple features on PyTorch using NVTabular library\n",
     "- Training and evaluating a Transformer-based (XLNET-MLM) session-based recommendation model with multiple features"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "15166c46",
+   "metadata": {},
    "source": [
     "## Build a DL model with Transformers4Rec library  "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d4d63f2c",
+   "metadata": {},
    "source": [
     "Transformers4Rec supports multiple input features and provides configurable building blocks that can be easily combined for custom architectures:\n",
     "\n",
@@ -68,33 +75,38 @@
     "-  [NextItemPredictionTask](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.tf.NextItemPredictionTask) is the class to support next item prediction task.\n",
     "\n",
     "You can check the [full documentation](https://nvidia-merlin.github.io/Transformers4Rec/main/index.html) of Transformers4Rec if needed."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "fdc7bee9",
+   "metadata": {},
    "source": [
     "Figure 1 illustrates Transformers4Rec meta-architecture and how each module/block interacts with each other."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5a14d725",
+   "metadata": {},
    "source": [
     "![tf4rec_meta](images/tf4rec_meta2.png)"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "eb70cd9c",
+   "metadata": {},
    "source": [
     "### Imports required libraries"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "e2b467cc",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "import os\n",
@@ -105,49 +117,46 @@
     "\n",
     "from transformers4rec import tf as tr\n",
     "from transformers4rec.tf.ranking_metric import NDCGAt, AvgPrecisionAt, RecallAt"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "8294cd4c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import cudf\n",
     "import dask_cudf\n",
     "from cudf.io.parquet import ParquetWriter as pwriter_cudf\n",
     "from dask_cudf.io.parquet import CudfEngine"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f70641da",
+   "metadata": {},
    "source": [
     "Transformers4Rec library relies on a schema object to automatically build all necessary layers to represent, normalize and aggregate input features. As you can see below, `schema.pb` is a protobuf file that contains metadata including statistics about features such as cardinality, min and max values and also tags features based on their characteristics and dtypes (e.g., categorical, continuous, list, integer)."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0ca423bb",
+   "metadata": {},
    "source": [
     "### Manually set the schema "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "source": [
-    "from merlin_standard_lib import Schema\n",
-    "SCHEMA_PATH = \"schema.pb\"\n",
-    "schema = Schema().from_proto_text(SCHEMA_PATH)\n",
-    "!cat $SCHEMA_PATH"
-   ],
+   "id": "fb551d7e",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "feature {\n",
       "  name: \"session_id\"\n",
@@ -239,45 +248,57 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "from merlin_standard_lib import Schema\n",
+    "SCHEMA_PATH = \"schema.pb\"\n",
+    "schema = Schema().from_proto_text(SCHEMA_PATH)\n",
+    "!cat $SCHEMA_PATH"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "d89e7eb7",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# You can select a subset of features for training\n",
     "schema = schema.select_by_name(['item_id-list_trim', \n",
     "                                'category-list_trim', \n",
     "                                'timestamp/weekday/sin-list_trim',\n",
     "                                'timestamp/age_days-list_trim'])"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "637b1e8c",
+   "metadata": {},
    "source": [
     "### Define the sequential input module"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8ff929e8",
+   "metadata": {},
    "source": [
     "Below we define our `input` block using the `TabularSequenceFeatures` [class](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/features/sequence.py#L121). The `from_schema()` method processes the schema and creates the necessary layers to represent features and aggregate them. It keeps only features tagged as `categorical` and `continuous` and supports data aggregation methods like `concat` and `elementwise-sum` techniques. It also support data augmentation techniques like stochastic swap noise. It outputs an interaction representation after combining all features and also the input mask according to the training task (more on this later).\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "48e69eef",
+   "metadata": {},
    "source": [
     "The `max_sequence_length` argument defines the maximum sequence length of our sequential input, and if `continuous_projection` argument is set, all numerical features are concatenated and projected by an MLP block so that continuous features are represented by a vector of size defined by user, which is `64` in this example."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "c5bc1bb2",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "inputs = tr.TabularSequenceFeatures.from_schema(\n",
     "        schema,\n",
@@ -286,12 +307,12 @@
     "        d_output=100,\n",
     "        masking=\"mlm\",\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2b8234c1",
+   "metadata": {},
    "source": [
     "The output of the `TabularSequenceFeatures` module is the sequence of interactions embeddings vectors defined in the following steps:\n",
     "- 1. Create sequence inputs: If the schema contains non sequential features, expand each feature to a sequence by repeating the value as many as the `max_sequence_length` value.  \n",
@@ -299,30 +320,34 @@
     "- 3. Project scalar values if `continuous_projection` is set : Apply an MLP layer with hidden size equal to `continuous_projection` vector size value. The resulting tensor is of shape (batch_size, max_sequence_length, continuous_projection).\n",
     "- 4. Aggregate the list of features vectors to represent each interaction in the sequence with one vector: For example, `concat` will concat all vectors based on the last dimension `-1` and the resulting tensor will be of shape (batch_size, max_sequence_length, D) where D is the sum over all embedding dimensions and the value of continuous_projection. \n",
     "- 5. If masking schema is set (needed only for the NextItemPredictionTask training), the masked labels are derived from the sequence of raw item-ids and the sequence of interactions embeddings are processed to mask information about the masked positions."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "438040e6",
+   "metadata": {},
    "source": [
     "### Define the Transformer Block"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e732ac9c",
+   "metadata": {},
    "source": [
     "In the next cell, the whole model is build with a few lines of code. \n",
     "Here is a brief explanation of the main classes:  \n",
     "- [XLNetConfig](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/config/transformer.py#L261) - We have injected in the HF transformers config classes like `XLNetConfig` the `build()` method, that provides default configuration to Transformer architectures for session-based recommendation. Here we use it to instantiate and configure an XLNET architecture.  \n",
     "- [TransformerBlock](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/block/transformer.py#L42) class integrates with HF Transformers, which are made available as a sequence processing module for session-based and sequential-based recommendation models.  \n",
     "- [NextItemPredictionTask](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/405e3142f1274b1b0d642f4834ac437f2549cd33/transformers4rec/tf/model/prediction_task.py#82) supports the next-item prediction task. We also support other predictions [tasks](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/model/prediction_task.py), like classification and regression for the whole sequence. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "485f788e",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Define XLNetConfig class and set default parameters for HF XLNet config  \n",
     "transformer_config = tr.XLNetConfig.build(\n",
@@ -343,34 +368,38 @@
     "task = tr.NextItemPredictionTask(weight_tying=True, metrics=metrics)\n",
     " \n",
     "model = task.to_model(body=body)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "67370948",
+   "metadata": {},
    "source": [
     "### Train the model "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ea3a46c8",
+   "metadata": {},
    "source": [
     "We use the NVTabular `KerasSequenceLoader` Dataloader for optimized loading of multiple features from input parquet files. You can learn more about this data loader [here](https://nvidia-merlin.github.io/NVTabular/main/training/tensorflow.html)."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "a8b8b52b",
+   "metadata": {},
    "source": [
     "### **Set DataLoader**"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "46752b38",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "x_cat_names, x_cont_names = ['category-list_trim', 'item_id-list_trim'], ['timestamp/age_days-list_trim', 'timestamp/weekday/sin-list_trim']\n",
     "\n",
@@ -392,20 +421,22 @@
     "        sparse_as_dense=True,\n",
     "    )\n",
     "    return dataloader.map(lambda X, y: (X, []))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8c7000f4",
+   "metadata": {},
    "source": [
     "## Set training params"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "cbf7168c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import tensorflow as tf\n",
     "lr_schedule = tf.keras.optimizers.schedules.CosineDecay(\n",
@@ -413,102 +444,78 @@
     "    decay_steps=1.5)\n",
     "optimizer = tf.keras.optimizers.Adam(learning_rate=lr_schedule)\n",
     "model.compile(optimizer=\"adam\", run_eagerly=True)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "81b0c31b",
+   "metadata": {},
    "source": [
     "## Daily Fine-Tuning: Training over a time window"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c800186a",
+   "metadata": {},
    "source": [
     "Here we do daily fine-tuning meaning that we use the first day to train and second day to evaluate, then we use the second day data to train the model by resuming from the first step, and evaluate on the third day, so on so forth."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f6dab6e8",
+   "metadata": {},
    "source": [
     "- Define the output folder of the processed parquet files"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
+   "id": "0769a10d",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "OUTPUT_DIR = os.environ.get(\"OUTPUT_DIR\", \"/workspace/data/sessions_by_day\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
+   "id": "474384eb",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import warnings\n",
     "warnings.filterwarnings('ignore')"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "source": [
-    "start_time_window_index = 1\n",
-    "final_time_window_index = 3\n",
-    "#Iterating over days of one week\n",
-    "for time_index in range(start_time_window_index, final_time_window_index):\n",
-    "    # Set data \n",
-    "    time_index_train = time_index\n",
-    "    time_index_eval = time_index + 1\n",
-    "    train_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_train}/train.parquet\"))\n",
-    "    eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
-    "    print(train_paths)\n",
-    "\n",
-    "    # Train on day related to time_index \n",
-    "    print('*'*20)\n",
-    "    print(\"Launch training for day %s are:\" %time_index)\n",
-    "    print('*'*20 + '\\n')\n",
-    "    train_loader = get_dataloader(train_paths) \n",
-    "    losses = model.fit(train_loader, epochs=5, verbose=0, )\n",
-    "    model.reset_metrics()\n",
-    "    print('finished')\n",
-    "    # Evaluate on the following day\n",
-    "    eval_loader = get_dataloader(eval_paths) \n",
-    "    eval_metrics = model.evaluate(eval_loader, return_dict=True)\n",
-    "    print('*'*20)\n",
-    "    print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
-    "    print('\\n' + '*'*20 + '\\n')\n",
-    "    for key in sorted(eval_metrics.keys()):\n",
-    "        print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
-   ],
+   "execution_count": 15,
+   "id": "15f04561",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "['/workspace/data/sessions_by_day/1/train.parquet']\n",
       "********************\n",
       "Launch training for day 1 are:\n",
       "********************\n",
       "\n",
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:AutoGraph could not transform <bound method Socket.send of <zmq.sugar.socket.Socket object at 0x7fa832b2d6a0>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module, class, method, function, traceback, frame, or code object was expected, got cython_function_or_method\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n",
-      "WARNING: AutoGraph could not transform <bound method Socket.send of <zmq.sugar.socket.Socket object at 0x7fa832b2d6a0>> and will run it as-is.\n",
-      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
-      "Cause: module, class, method, function, traceback, frame, or code object was expected, got cython_function_or_method\n",
-      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n",
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
       "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
       "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
       "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
@@ -580,23 +587,23 @@
       "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
       "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
       "finished\n",
-      "2/2 [==============================] - 1s 462ms/step - eval_ndcg_at_1_1: 0.9884 - eval_ndcg_at_1_5: 0.9884 - eval_ndcg_at_1_20: 0.9884 - eval_ndcg_at_1_40: 0.9884 - eval_recall_at_1_1: 0.9306 - eval_recall_at_1_5: 0.9464 - eval_recall_at_1_20: 0.9811 - eval_recall_at_1_40: 0.9884 - loss: 1.6877 - regularization_loss: 0.0000e+00 - total_loss: 1.6877\n",
+      "2/2 [==============================] - 1s 467ms/step - eval_ndcg_at_11: 0.9784 - eval_ndcg_at_15: 0.9784 - eval_ndcg_at_120: 0.9784 - eval_ndcg_at_140: 0.9784 - eval_recall_at_11: 0.8840 - eval_recall_at_15: 0.9635 - eval_recall_at_120: 0.9784 - eval_recall_at_140: 0.9784 - loss: 1.6354 - regularization_loss: 0.0000e+00 - total_loss: 1.6354\n",
       "********************\n",
       "Eval results for day 2 are:\t\n",
       "\n",
       "********************\n",
       "\n",
-      " eval_ndcg_at_1_1 = 0.9890109896659851\n",
-      " eval_ndcg_at_1_20 = 0.9890109896659851\n",
-      " eval_ndcg_at_1_40 = 0.9890109896659851\n",
-      " eval_ndcg_at_1_5 = 0.9890109896659851\n",
-      " eval_recall_at_1_1 = 0.9340659379959106\n",
-      " eval_recall_at_1_20 = 0.9780219793319702\n",
-      " eval_recall_at_1_40 = 0.9890109896659851\n",
-      " eval_recall_at_1_5 = 0.9450549483299255\n",
-      " loss = 1.6672356128692627\n",
+      " eval_ndcg_at_11 = 0.9702970385551453\n",
+      " eval_ndcg_at_120 = 0.9702970385551453\n",
+      " eval_ndcg_at_140 = 0.9702970385551453\n",
+      " eval_ndcg_at_15 = 0.9702970385551453\n",
+      " eval_recall_at_11 = 0.8712871074676514\n",
+      " eval_recall_at_120 = 0.9702970385551453\n",
+      " eval_recall_at_140 = 0.9702970385551453\n",
+      " eval_recall_at_15 = 0.9504950642585754\n",
+      " loss = 1.7537225484848022\n",
       " regularization_loss = 0\n",
-      " total_loss = 1.6672356128692627\n",
+      " total_loss = 1.7537225484848022\n",
       "['/workspace/data/sessions_by_day/2/train.parquet']\n",
       "********************\n",
       "Launch training for day 2 are:\n",
@@ -672,628 +679,275 @@
       "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
       "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
       "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
       "finished\n",
-      "2/2 [==============================] - 1s 550ms/step - eval_ndcg_at_1_1: 0.9942 - eval_ndcg_at_1_5: 0.9942 - eval_ndcg_at_1_20: 0.9942 - eval_ndcg_at_1_40: 0.9942 - eval_recall_at_1_1: 0.9424 - eval_recall_at_1_5: 0.9763 - eval_recall_at_1_20: 0.9942 - eval_recall_at_1_40: 0.9942 - loss: 0.4446 - regularization_loss: 0.0000e+00 - total_loss: 0.4446\n",
+      "2/2 [==============================] - 1s 409ms/step - eval_ndcg_at_11: 0.9732 - eval_ndcg_at_15: 0.9732 - eval_ndcg_at_120: 0.9732 - eval_ndcg_at_140: 0.9732 - eval_recall_at_11: 0.9422 - eval_recall_at_15: 0.9559 - eval_recall_at_120: 0.9732 - eval_recall_at_140: 0.9732 - loss: 0.5419 - regularization_loss: 0.0000e+00 - total_loss: 0.5419\n",
       "********************\n",
       "Eval results for day 3 are:\t\n",
       "\n",
       "********************\n",
       "\n",
-      " eval_ndcg_at_1_1 = 1.0\n",
-      " eval_ndcg_at_1_20 = 1.0\n",
-      " eval_ndcg_at_1_40 = 1.0\n",
-      " eval_ndcg_at_1_5 = 1.0\n",
-      " eval_recall_at_1_1 = 0.9368420839309692\n",
-      " eval_recall_at_1_20 = 1.0\n",
-      " eval_recall_at_1_40 = 1.0\n",
-      " eval_recall_at_1_5 = 0.9789473414421082\n",
-      " loss = 0.4243243932723999\n",
+      " eval_ndcg_at_11 = 0.9659090638160706\n",
+      " eval_ndcg_at_120 = 0.9659090638160706\n",
+      " eval_ndcg_at_140 = 0.9659090638160706\n",
+      " eval_ndcg_at_15 = 0.9659090638160706\n",
+      " eval_recall_at_11 = 0.9318181872367859\n",
+      " eval_recall_at_120 = 0.9659090638160706\n",
+      " eval_recall_at_140 = 0.9659090638160706\n",
+      " eval_recall_at_15 = 0.9431818127632141\n",
+      " loss = 0.6144798398017883\n",
       " regularization_loss = 0\n",
-      " total_loss = 0.4243243932723999\n"
+      " total_loss = 0.6144798398017883\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "start_time_window_index = 1\n",
+    "final_time_window_index = 3\n",
+    "#Iterating over days of one week\n",
+    "for time_index in range(start_time_window_index, final_time_window_index):\n",
+    "    # Set data \n",
+    "    time_index_train = time_index\n",
+    "    time_index_eval = time_index + 1\n",
+    "    train_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_train}/train.parquet\"))\n",
+    "    eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
+    "    print(train_paths)\n",
+    "\n",
+    "    # Train on day related to time_index \n",
+    "    print('*'*20)\n",
+    "    print(\"Launch training for day %s are:\" %time_index)\n",
+    "    print('*'*20 + '\\n')\n",
+    "    train_loader = get_dataloader(train_paths) \n",
+    "    losses = model.fit(train_loader, epochs=5, verbose=0, )\n",
+    "    model.reset_metrics()\n",
+    "    print('finished')\n",
+    "    # Evaluate on the following day\n",
+    "    eval_loader = get_dataloader(eval_paths) \n",
+    "    eval_metrics = model.evaluate(eval_loader, return_dict=True)\n",
+    "    print('*'*20)\n",
+    "    print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
+    "    print('\\n' + '*'*20 + '\\n')\n",
+    "    for key in sorted(eval_metrics.keys()):\n",
+    "        print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
+   "id": "6a2fece8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2/2 [==============================] - 1s 527ms/step - eval_ndcg_at_11: 0.9946 - eval_ndcg_at_15: 0.9946 - eval_ndcg_at_120: 0.9946 - eval_ndcg_at_140: 0.9946 - eval_recall_at_11: 0.9675 - eval_recall_at_15: 0.9819 - eval_recall_at_120: 0.9891 - eval_recall_at_140: 0.9946 - loss: 0.3619 - regularization_loss: 0.0000e+00 - total_loss: 0.3619\n"
+     ]
+    }
+   ],
    "source": [
     "# Evaluate on the following day\n",
     "time_index_eval = 5\n",
     "eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
     "eval_loader = get_dataloader(eval_paths) \n",
     "eval_metrics = model.evaluate(eval_loader, return_dict=True, )"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "2/2 [==============================] - 1s 541ms/step - eval_ndcg_at_1_1: 0.9900 - eval_ndcg_at_1_5: 0.9900 - eval_ndcg_at_1_20: 0.9900 - eval_ndcg_at_1_40: 0.9900 - eval_recall_at_1_1: 0.9700 - eval_recall_at_1_5: 0.9721 - eval_recall_at_1_20: 0.9900 - eval_recall_at_1_40: 0.9900 - loss: 0.3703 - regularization_loss: 0.0000e+00 - total_loss: 0.3703\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "source": [
-    "eval_metrics"
-   ],
+   "execution_count": 17,
+   "id": "2336a091",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "{'eval_ndcg_at_1_1': 0.991304337978363,\n",
-       " 'eval_ndcg_at_1_5': 0.991304337978363,\n",
-       " 'eval_ndcg_at_1_20': 0.991304337978363,\n",
-       " 'eval_ndcg_at_1_40': 0.991304337978363,\n",
-       " 'eval_recall_at_1_1': 0.9739130139350891,\n",
-       " 'eval_recall_at_1_5': 0.9739130139350891,\n",
-       " 'eval_recall_at_1_20': 0.991304337978363,\n",
-       " 'eval_recall_at_1_40': 0.991304337978363,\n",
-       " 'loss': 0.36306288838386536,\n",
+       "{'eval_ndcg_at_11': 1.0,\n",
+       " 'eval_ndcg_at_15': 1.0,\n",
+       " 'eval_ndcg_at_120': 1.0,\n",
+       " 'eval_ndcg_at_140': 1.0,\n",
+       " 'eval_recall_at_11': 0.9674796462059021,\n",
+       " 'eval_recall_at_15': 0.9837398529052734,\n",
+       " 'eval_recall_at_120': 0.9918699264526367,\n",
+       " 'eval_recall_at_140': 1.0,\n",
+       " 'loss': 0.3112412691116333,\n",
        " 'regularization_loss': 0,\n",
-       " 'total_loss': 0.36306288838386536}"
+       " 'total_loss': 0.3112412691116333}"
       ]
      },
+     "execution_count": 17,
      "metadata": {},
-     "execution_count": 14
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "eval_metrics"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "source": [
-    "print('*'*20)\n",
-    "print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
-    "print('\\n' + '*'*20 + '\\n')\n",
-    "for key in sorted(eval_metrics.keys()):\n",
-    "    print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
-   ],
+   "execution_count": 18,
+   "id": "771c32e7",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "********************\n",
       "Eval results for day 5 are:\t\n",
       "\n",
       "********************\n",
       "\n",
-      " eval_ndcg_at_1_1 = 0.991304337978363\n",
-      " eval_ndcg_at_1_20 = 0.991304337978363\n",
-      " eval_ndcg_at_1_40 = 0.991304337978363\n",
-      " eval_ndcg_at_1_5 = 0.991304337978363\n",
-      " eval_recall_at_1_1 = 0.9739130139350891\n",
-      " eval_recall_at_1_20 = 0.991304337978363\n",
-      " eval_recall_at_1_40 = 0.991304337978363\n",
-      " eval_recall_at_1_5 = 0.9739130139350891\n",
-      " loss = 0.36306288838386536\n",
+      " eval_ndcg_at_11 = 1.0\n",
+      " eval_ndcg_at_120 = 1.0\n",
+      " eval_ndcg_at_140 = 1.0\n",
+      " eval_ndcg_at_15 = 1.0\n",
+      " eval_recall_at_11 = 0.9674796462059021\n",
+      " eval_recall_at_120 = 0.9918699264526367\n",
+      " eval_recall_at_140 = 1.0\n",
+      " eval_recall_at_15 = 0.9837398529052734\n",
+      " loss = 0.3112412691116333\n",
       " regularization_loss = 0\n",
-      " total_loss = 0.36306288838386536\n"
+      " total_loss = 0.3112412691116333\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "print('*'*20)\n",
+    "print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
+    "print('\\n' + '*'*20 + '\\n')\n",
+    "for key in sorted(eval_metrics.keys()):\n",
+    "    print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5afa9bc5",
+   "metadata": {},
    "source": [
     "### Saves the model"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "source": [
-    "model.save('tmp/tensorflow')"
-   ],
+   "execution_count": 19,
+   "id": "5e264991",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
       "WARNING:tensorflow:Skipping full serialization of Keras layer TFSharedEmbeddings(), because it is not built.\n",
       "WARNING:tensorflow:Skipping full serialization of Keras layer Dropout(), because it is not built.\n",
       "WARNING:tensorflow:Skipping full serialization of Keras layer Dropout(), because it is not built.\n",
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
-      "WARNING:tensorflow:Skipping full serialization of Keras layer TFSequenceSummary(), because it is not built.\n",
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+      "WARNING:tensorflow:Skipping full serialization of Keras layer TFSequenceSummary(), because it is not built.\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
-     "text": [
-      "WARNING:absl:Function `_wrapped_model` contains input name(s) category-list_trim, item_id-list_trim, timestamp/age_days-list_trim, timestamp/weekday/sin-list_trim with unsupported characters which will be renamed to category_list_trim, item_id_list_trim, timestamp_age_days_list_trim, timestamp_weekday_sin_list_trim in the SavedModel.\n"
-     ]
-    },
-    {
      "output_type": "stream",
-     "name": "stdout",
      "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:absl:Function `_wrapped_model` contains input name(s) category-list_trim, item_id-list_trim, timestamp/age_days-list_trim, timestamp/weekday/sin-list_trim with unsupported characters which will be renamed to category_list_trim, item_id_list_trim, timestamp_age_days_list_trim, timestamp_weekday_sin_list_trim in the SavedModel.\n",
       "WARNING:absl:Found untraced functions such as sequential_block_1_layer_call_and_return_conditional_losses, sequential_block_1_layer_call_fn, next_item_prediction_task_layer_call_and_return_conditional_losses, next_item_prediction_task_layer_call_fn, sequential_block_1_layer_call_fn while saving (showing 5 of 205). These functions will not be directly callable after loading.\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "INFO:tensorflow:Assets written to: tmp/tensorflow/assets\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "INFO:tensorflow:Assets written to: tmp/tensorflow/assets\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "model.save('tmp/tensorflow')"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4d7a153e",
+   "metadata": {},
    "source": [
     "### Reloads the model"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 42,
+   "id": "a3994956",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "model = tf.keras.models.load_model('./tmp/tensorflow')"
-   ],
+    "custom_objects = dict([(e.__class__.__name__, e) for e in task.metrics])\n",
+    "custom_objects.update({\"Model\": tr.model.base.Model})\n",
+    "model = tf.keras.models.load_model('./tmp/tensorflow', custom_objects=custom_objects)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "3d4d96fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch = next(iter(eval_loader))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "d99c2442",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "error",
-     "ename": "KeyError",
-     "evalue": "'layers'",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_383189/1763871290.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mmodel\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkeras\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'./tmp/tensorflow'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/save.py\u001b[0m in \u001b[0;36mload_model\u001b[0;34m(filepath, custom_objects, compile, options)\u001b[0m\n\u001b[1;32m    203\u001b[0m         \u001b[0mfilepath\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpath_to_string\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    204\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 205\u001b[0;31m           \u001b[0;32mreturn\u001b[0m \u001b[0msaved_model_load\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcompile\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    206\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    207\u001b[0m   raise IOError(\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36mload\u001b[0;34m(path, compile, options)\u001b[0m\n\u001b[1;32m    132\u001b[0m   \u001b[0;31m# Recreate layers and metrics using the info stored in the metadata.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    133\u001b[0m   \u001b[0mkeras_loader\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mKerasObjectLoader\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmetadata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobject_graph_def\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 134\u001b[0;31m   \u001b[0mkeras_loader\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_layers\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcompile\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcompile\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    135\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    136\u001b[0m   \u001b[0;31m# Generate a dictionary of all loaded nodes.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36mload_layers\u001b[0;34m(self, compile)\u001b[0m\n\u001b[1;32m    392\u001b[0m         \u001b[0;32mcontinue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    393\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 394\u001b[0;31m       self.loaded_nodes[node_metadata.node_id] = self._load_layer(\n\u001b[0m\u001b[1;32m    395\u001b[0m           \u001b[0mnode_metadata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnode_id\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnode_metadata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0midentifier\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    396\u001b[0m           node_metadata.metadata)\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36m_load_layer\u001b[0;34m(self, node_id, identifier, metadata)\u001b[0m\n\u001b[1;32m    434\u001b[0m     \u001b[0;31m# Detect whether this object can be revived from the config. If not, then\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    435\u001b[0m     \u001b[0;31m# revive from the SavedModel instead.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 436\u001b[0;31m     \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msetter\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_revive_from_config\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0midentifier\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmetadata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnode_id\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    437\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mobj\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    438\u001b[0m       \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msetter\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrevive_custom_object\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0midentifier\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmetadata\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36m_revive_from_config\u001b[0;34m(self, identifier, metadata, node_id)\u001b[0m\n\u001b[1;32m    452\u001b[0m       obj = (\n\u001b[1;32m    453\u001b[0m           \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_revive_graph_network\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0midentifier\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmetadata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnode_id\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 454\u001b[0;31m           self._revive_layer_or_model_from_config(metadata, node_id))\n\u001b[0m\u001b[1;32m    455\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    456\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mobj\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36m_revive_layer_or_model_from_config\u001b[0;34m(self, metadata, node_id)\u001b[0m\n\u001b[1;32m    516\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    517\u001b[0m     \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 518\u001b[0;31m       obj = layers_module.deserialize(\n\u001b[0m\u001b[1;32m    519\u001b[0m           generic_utils.serialize_keras_class_and_config(\n\u001b[1;32m    520\u001b[0m               class_name, config, shared_object_id=shared_object_id))\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/layers/serialization.py\u001b[0m in \u001b[0;36mdeserialize\u001b[0;34m(config, custom_objects)\u001b[0m\n\u001b[1;32m    206\u001b[0m   \"\"\"\n\u001b[1;32m    207\u001b[0m   \u001b[0mpopulate_deserializable_objects\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 208\u001b[0;31m   return generic_utils.deserialize_keras_object(\n\u001b[0m\u001b[1;32m    209\u001b[0m       \u001b[0mconfig\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    210\u001b[0m       \u001b[0mmodule_objects\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mLOCAL\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mALL_OBJECTS\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/utils/generic_utils.py\u001b[0m in \u001b[0;36mdeserialize_keras_object\u001b[0;34m(identifier, module_objects, custom_objects, printable_module_name)\u001b[0m\n\u001b[1;32m    672\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    673\u001b[0m       \u001b[0;32mif\u001b[0m \u001b[0;34m'custom_objects'\u001b[0m \u001b[0;32min\u001b[0m \u001b[0marg_spec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 674\u001b[0;31m         deserialized_obj = cls.from_config(\n\u001b[0m\u001b[1;32m    675\u001b[0m             \u001b[0mcls_config\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    676\u001b[0m             custom_objects=dict(\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/engine/training.py\u001b[0m in \u001b[0;36mfrom_config\u001b[0;34m(cls, config, custom_objects)\u001b[0m\n\u001b[1;32m   2395\u001b[0m     \u001b[0;32mwith\u001b[0m \u001b[0mgeneric_utils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSharedObjectLoadingScope\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2396\u001b[0m       input_tensors, output_tensors, created_layers = (\n\u001b[0;32m-> 2397\u001b[0;31m           functional.reconstruct_from_config(config, custom_objects))\n\u001b[0m\u001b[1;32m   2398\u001b[0m       \u001b[0;31m# Initialize a model belonging to `cls`, which can be user-defined or\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2399\u001b[0m       \u001b[0;31m# `Functional`.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/engine/functional.py\u001b[0m in \u001b[0;36mreconstruct_from_config\u001b[0;34m(config, custom_objects, created_layers)\u001b[0m\n\u001b[1;32m   1270\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1271\u001b[0m   \u001b[0;31m# First, we create all layers and enqueue nodes to be processed\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1272\u001b[0;31m   \u001b[0;32mfor\u001b[0m \u001b[0mlayer_data\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mconfig\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'layers'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1273\u001b[0m     \u001b[0mprocess_layer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlayer_data\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1274\u001b[0m   \u001b[0;31m# Then we process nodes in order of layer depth.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'layers'"
-     ]
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(64, 50006), dtype=float32, numpy=\n",
+       "array([[-14.493961 , -15.484225 , -11.110427 , ..., -14.346155 ,\n",
+       "        -13.904466 , -12.666895 ],\n",
+       "       [-13.279946 , -15.803352 ,  -6.682808 , ..., -14.312171 ,\n",
+       "        -14.838006 , -13.458751 ],\n",
+       "       [-14.116868 , -13.203354 ,  -7.3250527, ..., -13.805136 ,\n",
+       "        -14.0072565, -14.038446 ],\n",
+       "       ...,\n",
+       "       [-16.1054   , -13.409816 ,  -7.595481 , ..., -15.479166 ,\n",
+       "        -14.379271 , -13.219385 ],\n",
+       "       [-13.628686 , -13.306683 ,  -9.541618 , ..., -13.696954 ,\n",
+       "        -14.751454 , -12.460076 ],\n",
+       "       [-13.796522 , -14.849159 , -11.28446  , ..., -13.630577 ,\n",
+       "        -14.95263  , -12.956992 ]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "model(batch[0])"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Re-compute eval metrics of validation data"
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "eval_data_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
-    "eval_loader = get_dataloader(eval_data_paths)"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "eval_metrics = model.evaluate(eval_loader)"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "for key in sorted(eval_metrics.keys()):\n",
-    "    print(\"  %s = %s\" % (key, str(eval_metrics[key])))"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
+   "id": "6c21d612",
+   "metadata": {},
    "source": [
     "That's it!  \n",
     "You have just trained your session-based recommendation model using Transformers4Rec."
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "Tip: We can easily log and visualize model training and evaluation on [Weights & Biases (W&B)](https://wandb.ai/home), [Tensorboard](https://www.tensorflow.org/tensorboard) and [NVIDIA DLLogger](https://github.com/NVIDIA/dllogger). By default, the HuggingFace transformers `Trainer` (which we extend) uses Weights & Biases (W&B) to log training and evaluation metrics, which provides nice results visualization and comparison between different runs."
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "tf.convert_to_tensor([0.5, 0.6])"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "dict(zip(['top_5', 'top_6'], tf.convert_to_tensor([0.5, 0.6])))"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {

--- a/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
+++ b/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
@@ -1,0 +1,1375 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "829d71e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 NVIDIA Corporation. All Rights Reserved.\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License.\n",
+    "# =============================================================================="
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95ebd562",
+   "metadata": {},
+   "source": [
+    "# Session-based Recommendation with XLNET"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee69e6c5",
+   "metadata": {},
+   "source": [
+    "In this notebook we introduce the [Transformers4Rec](https://github.com/NVIDIA-Merlin/Transformers4Rec) library for sequential and session-based recommendation. This notebook uses the PyTorch API, but a TensorFlow API is also available. Transformers4Rec integrates with the popular [HuggingFace’s Transformers](https://github.com/huggingface/transformers) and make it possible to experiment with cutting-edge implementation of the latest NLP Transformer architectures.  \n",
+    "\n",
+    "We demonstrate how to build a session-based recommendation model with the [XLNET](https://arxiv.org/abs/1906.08237) Transformer architecture. The XLNet architecture was designed to leverage the best of both auto-regressive language modeling and auto-encoding with its Permutation Language Modeling training method. In this example we will use XLNET with masked language modeling (MLM) training method, which showed very promising results in the experiments conducted in our [ACM RecSys'21 paper](https://github.com/NVIDIA-Merlin/publications/blob/main/2021_acm_recsys_transformers4rec/recsys21_transformers4rec_paper.pdf)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1dc0f40a",
+   "metadata": {},
+   "source": [
+    "In the previous notebook we went through our ETL pipeline with NVTabular library, and created sequential features to be used in training a session-based recommendation model. In this notebook we will learn:\n",
+    "\n",
+    "- Accelerating data loading of parquet files with multiple features on PyTorch using NVTabular library\n",
+    "- Training and evaluating a Transformer-based (XLNET-MLM) session-based recommendation model with multiple features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2cfe10b",
+   "metadata": {},
+   "source": [
+    "## Build a DL model with Transformers4Rec library  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d4ccc5b",
+   "metadata": {},
+   "source": [
+    "Transformers4Rec supports multiple input features and provides configurable building blocks that can be easily combined for custom architectures:\n",
+    "\n",
+    "- [TabularSequenceFeatures](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.TabularSequenceFeatures) class that reads from schema and creates an input block. This input module combines different types of features (continuous, categorical & text) to a sequence.\n",
+    "-  [MaskSequence](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/torch/masking.py) to define masking schema and prepare the masked inputs and labels for the selected LM task.\n",
+    "-  [TransformerBlock](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.TransformerBlock) class that supports HuggingFace Transformers for session-based and sequential-based recommendation models.\n",
+    "-  [SequentialBlock](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.SequentialBlock) creates the body by mimicking [torch.nn.sequential](https://pytorch.org/docs/stable/generated/torch.nn.Sequential.html) class. It is designed to define our model as a sequence of layers.\n",
+    "-  [Head](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.Head) where we define the prediction task of the model.\n",
+    "-  [NextItemPredictionTask](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.NextItemPredictionTask) is the class to support next item prediction task.\n",
+    "- [Trainer](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.Trainer) extends the `Trainer` class from HF transformers and manages the model training and evaluation.\n",
+    "\n",
+    "You can check the [full documentation](https://nvidia-merlin.github.io/Transformers4Rec/main/index.html) of Transformers4Rec if needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fbdb9c8",
+   "metadata": {},
+   "source": [
+    "Figure 1 illustrates Transformers4Rec meta-architecture and how each module/block interacts with each other."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "396076b2",
+   "metadata": {},
+   "source": [
+    "![tf4rec_meta](images/tf4rec_meta2.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e7eb33f",
+   "metadata": {},
+   "source": [
+    "### Imports required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7f3330de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import os\n",
+    "os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3' \n",
+    "import glob\n",
+    "\n",
+    "from nvtabular.loader.tensorflow import KerasSequenceLoader\n",
+    "\n",
+    "from transformers4rec import tf as tr\n",
+    "from transformers4rec.tf.ranking_metric import NDCGAt, AvgPrecisionAt, RecallAt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e875b93d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cudf\n",
+    "import dask_cudf\n",
+    "from cudf.io.parquet import ParquetWriter as pwriter_cudf\n",
+    "from dask_cudf.io.parquet import CudfEngine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abc20f09",
+   "metadata": {},
+   "source": [
+    "Transformers4Rec library relies on a schema object to automatically build all necessary layers to represent, normalize and aggregate input features. As you can see below, `schema.pb` is a protobuf file that contains metadata including statistics about features such as cardinality, min and max values and also tags features based on their characteristics and dtypes (e.g., categorical, continuous, list, integer)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3da652df",
+   "metadata": {},
+   "source": [
+    "### Manually set the schema "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0abd4957",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "feature {\n",
+      "  name: \"session_id\"\n",
+      "  type: INT\n",
+      "  int_domain {\n",
+      "    name: \"session_id\"\n",
+      "    min: 1\n",
+      "    max: 100001\n",
+      "    is_categorical: false\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"groupby_col\"\n",
+      "  }\n",
+      "}\n",
+      "feature {\n",
+      "  name: \"category-list_trim\"\n",
+      "  value_count {\n",
+      "    min: 2\n",
+      "    max: 20\n",
+      "  }\n",
+      "  type: INT\n",
+      "  int_domain {\n",
+      "    name: \"category-list_trim\"\n",
+      "    min: 1\n",
+      "    max: 400\n",
+      "    is_categorical: true\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"list\"\n",
+      "    tag: \"categorical\"\n",
+      "    tag: \"item\"\n",
+      "  }\n",
+      "}\n",
+      "feature {\n",
+      "  name: \"item_id-list_trim\"\n",
+      "  value_count {\n",
+      "    min: 2\n",
+      "    max: 20\n",
+      "  }\n",
+      "  type: INT\n",
+      "  int_domain {\n",
+      "    name: \"item_id/list\"\n",
+      "    min: 1\n",
+      "    max: 50005\n",
+      "    is_categorical: true\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"item_id\"\n",
+      "    tag: \"list\"\n",
+      "    tag: \"categorical\"\n",
+      "    tag: \"item\"\n",
+      "  }\n",
+      "}\n",
+      "feature {\n",
+      "  name: \"timestamp/age_days-list_trim\"\n",
+      "  value_count {\n",
+      "    min: 2\n",
+      "    max: 20\n",
+      "  }\n",
+      "  type: FLOAT\n",
+      "  float_domain {\n",
+      "    name: \"timestamp/age_days-list_trim\"\n",
+      "    min: 0.0000003\n",
+      "    max: 0.9999999\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"continuous\"\n",
+      "    tag: \"list\"\n",
+      "  }\n",
+      "}\n",
+      "feature {\n",
+      "  name: \"timestamp/weekday/sin-list_trim\"\n",
+      "  value_count {\n",
+      "    min: 2\n",
+      "    max: 20\n",
+      "  }\n",
+      "  type: FLOAT\n",
+      "  float_domain {\n",
+      "    name: \"timestamp/weekday-sin_trim\"\n",
+      "    min: 0.0000003\n",
+      "    max: 0.9999999\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"continuous\"\n",
+      "    tag: \"time\"\n",
+      "    tag: \"list\"\n",
+      "  }\n",
+      "}"
+     ]
+    }
+   ],
+   "source": [
+    "from merlin_standard_lib import Schema\n",
+    "SCHEMA_PATH = \"schema.pb\"\n",
+    "schema = Schema().from_proto_text(SCHEMA_PATH)\n",
+    "!cat $SCHEMA_PATH"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8d5cc0e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can select a subset of features for training\n",
+    "schema = schema.select_by_name(['item_id-list_trim', \n",
+    "                                'category-list_trim', \n",
+    "                                'timestamp/weekday/sin-list_trim',\n",
+    "                                'timestamp/age_days-list_trim'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a72110a",
+   "metadata": {},
+   "source": [
+    "### Define the sequential input module"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62368d00",
+   "metadata": {},
+   "source": [
+    "Below we define our `input` block using the `TabularSequenceFeatures` [class](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/features/sequence.py#L121). The `from_schema()` method processes the schema and creates the necessary layers to represent features and aggregate them. It keeps only features tagged as `categorical` and `continuous` and supports data aggregation methods like `concat` and `elementwise-sum` techniques. It also support data augmentation techniques like stochastic swap noise. It outputs an interaction representation after combining all features and also the input mask according to the training task (more on this later).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f507e843",
+   "metadata": {},
+   "source": [
+    "The `max_sequence_length` argument defines the maximum sequence length of our sequential input, and if `continuous_projection` argument is set, all numerical features are concatenated and projected by an MLP block so that continuous features are represented by a vector of size defined by user, which is `64` in this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "030a4caf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs = tr.TabularSequenceFeatures.from_schema(\n",
+    "        schema,\n",
+    "        max_sequence_length=20,\n",
+    "        continuous_projection=64,\n",
+    "        d_output=100,\n",
+    "        masking=\"mlm\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90acf861",
+   "metadata": {},
+   "source": [
+    "The output of the `TabularSequenceFeatures` module is the sequence of interactions embeddings vectors defined in the following steps:\n",
+    "- 1. Create sequence inputs: If the schema contains non sequential features, expand each feature to a sequence by repeating the value as many as the `max_sequence_length` value.  \n",
+    "- 2. Get a representation vector of categorical features: Project each sequential categorical feature using the related embedding table. The resulting tensor is of shape (bs, max_sequence_length, embed_dim).\n",
+    "- 3. Project scalar values if `continuous_projection` is set : Apply an MLP layer with hidden size equal to `continuous_projection` vector size value. The resulting tensor is of shape (batch_size, max_sequence_length, continuous_projection).\n",
+    "- 4. Aggregate the list of features vectors to represent each interaction in the sequence with one vector: For example, `concat` will concat all vectors based on the last dimension `-1` and the resulting tensor will be of shape (batch_size, max_sequence_length, D) where D is the sum over all embedding dimensions and the value of continuous_projection. \n",
+    "- 5. If masking schema is set (needed only for the NextItemPredictionTask training), the masked labels are derived from the sequence of raw item-ids and the sequence of interactions embeddings are processed to mask information about the masked positions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "199e395f",
+   "metadata": {},
+   "source": [
+    "### Define the Transformer Block"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9b3b90d",
+   "metadata": {},
+   "source": [
+    "In the next cell, the whole model is build with a few lines of code. \n",
+    "Here is a brief explanation of the main classes:  \n",
+    "- [XLNetConfig](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/config/transformer.py#L261) - We have injected in the HF transformers config classes like `XLNetConfig`the `build()` method, that provides default configuration to Transformer architectures for session-based recommendation. Here we use it to instantiate and configure an XLNET architecture.  \n",
+    "- [TransformerBlock](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/block/transformer.py#L42) class integrates with HF Transformers, which are made available as a sequence processing module for session-based and sequential-based recommendation models.  \n",
+    "- [NextItemPredictionTask](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/405e3142f1274b1b0d642f4834ac437f2549cd33/transformers4rec/tf/model/prediction_task.py#82) supports the next-item prediction task. We also support other predictions [tasks](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/model/prediction_task.py), like classification and regression for the whole sequence. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c8d3ef7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define XLNetConfig class and set default parameters for HF XLNet config  \n",
+    "transformer_config = tr.XLNetConfig.build(\n",
+    "    d_model=64, n_head=4, n_layer=2, total_seq_length=20\n",
+    ")\n",
+    "# Define the model block including: inputs, masking, projection and transformer block.\n",
+    "body = tr.SequentialBlock(\n",
+    "    [inputs, tr.MLPBlock([64]), tr.TransformerBlock(transformer_config, masking=inputs.masking)]\n",
+    ")\n",
+    "\n",
+    "# Defines the evaluation top-N metrics and the cut-offs\n",
+    "metrics = (\n",
+    "    NDCGAt(top_ks=[1, 5, 20, 40], labels_onehot=True),  \n",
+    "    RecallAt(top_ks=[1, 5, 20, 40], labels_onehot=True)\n",
+    "          )\n",
+    "\n",
+    "# link task to body and generate the end-to-end keras model\n",
+    "task = tr.NextItemPredictionTask(weight_tying=True, metrics=metrics)\n",
+    " \n",
+    "model = task.to_model(body=body)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad1b5657",
+   "metadata": {},
+   "source": [
+    "### Train the model "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0b46cc2",
+   "metadata": {},
+   "source": [
+    "We use the NVTabular `KerasSequenceLoader` Dataloader for optimized loading of multiple features from input parquet files. You can learn more about this data loader [here](https://nvidia-merlin.github.io/NVTabular/main/training/tensorflow.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7653df09",
+   "metadata": {},
+   "source": [
+    "### **Set DataLoader**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dc3f631c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_cat_names, x_cont_names = ['category-list_trim', 'item_id-list_trim'], ['timestamp/age_days-list_trim', 'timestamp/weekday/sin-list_trim']\n",
+    "\n",
+    "# dictionary representing max sequence length for column\n",
+    "sparse_features_max = {\n",
+    "    fname: 20\n",
+    "    for fname in x_cat_names + x_cont_names\n",
+    "}\n",
+    "\n",
+    "def get_dataloader(paths_or_dataset, batch_size=64):\n",
+    "    dataloader = KerasSequenceLoader(\n",
+    "        paths_or_dataset,\n",
+    "        batch_size=batch_size,\n",
+    "        label_names=None,\n",
+    "        cat_names=x_cat_names,\n",
+    "        cont_names=x_cont_names,\n",
+    "        sparse_names=list(sparse_features_max.keys()),\n",
+    "        sparse_max=sparse_features_max,\n",
+    "        sparse_as_dense=True,\n",
+    "    )\n",
+    "    return dataloader.map(lambda X, y: (X, []))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94ddd25f",
+   "metadata": {},
+   "source": [
+    "## Set training params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d9ebc653",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "lr_schedule = tf.keras.optimizers.schedules.CosineDecay(\n",
+    "    initial_learning_rate=0.0005,\n",
+    "    decay_steps=1.5)\n",
+    "optimizer = tf.keras.optimizers.Adam(learning_rate=lr_schedule)\n",
+    "model.compile(optimizer=\"adam\", run_eagerly=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67175c07",
+   "metadata": {},
+   "source": [
+    "## Daily Fine-Tuning: Training over a time window"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d86c2575",
+   "metadata": {},
+   "source": [
+    "Here we do daily fine-tuning meaning that we use the first day to train and second day to evaluate, then we use the second day data to train the model by resuming from the first step, and evaluate on the third day, so on so forth."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7484df73",
+   "metadata": {},
+   "source": [
+    "- Define the output folder of the processed parquet files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "80bed8a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OUTPUT_DIR = os.environ.get(\"OUTPUT_DIR\", \"/workspace/data/sessions_by_day\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ceb428a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "fb812e2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['/workspace/data/sessions_by_day/1/train.parquet']\n",
+      "********************\n",
+      "Launch training for day 1 are:\n",
+      "********************\n",
+      "\n",
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
+      "WARNING:tensorflow:AutoGraph could not transform <bound method Socket.send of <zmq.sugar.socket.Socket object at 0x7fa832b2d6a0>> and will run it as-is.\n",
+      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
+      "Cause: module, class, method, function, traceback, frame, or code object was expected, got cython_function_or_method\n",
+      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n",
+      "WARNING: AutoGraph could not transform <bound method Socket.send of <zmq.sugar.socket.Socket object at 0x7fa832b2d6a0>> and will run it as-is.\n",
+      "Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.\n",
+      "Cause: module, class, method, function, traceback, frame, or code object was expected, got cython_function_or_method\n",
+      "To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert\n",
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "finished\n",
+      "2/2 [==============================] - 1s 462ms/step - eval_ndcg_at_1_1: 0.9884 - eval_ndcg_at_1_5: 0.9884 - eval_ndcg_at_1_20: 0.9884 - eval_ndcg_at_1_40: 0.9884 - eval_recall_at_1_1: 0.9306 - eval_recall_at_1_5: 0.9464 - eval_recall_at_1_20: 0.9811 - eval_recall_at_1_40: 0.9884 - loss: 1.6877 - regularization_loss: 0.0000e+00 - total_loss: 1.6877\n",
+      "********************\n",
+      "Eval results for day 2 are:\t\n",
+      "\n",
+      "********************\n",
+      "\n",
+      " eval_ndcg_at_1_1 = 0.9890109896659851\n",
+      " eval_ndcg_at_1_20 = 0.9890109896659851\n",
+      " eval_ndcg_at_1_40 = 0.9890109896659851\n",
+      " eval_ndcg_at_1_5 = 0.9890109896659851\n",
+      " eval_recall_at_1_1 = 0.9340659379959106\n",
+      " eval_recall_at_1_20 = 0.9780219793319702\n",
+      " eval_recall_at_1_40 = 0.9890109896659851\n",
+      " eval_recall_at_1_5 = 0.9450549483299255\n",
+      " loss = 1.6672356128692627\n",
+      " regularization_loss = 0\n",
+      " total_loss = 1.6672356128692627\n",
+      "['/workspace/data/sessions_by_day/2/train.parquet']\n",
+      "********************\n",
+      "Launch training for day 2 are:\n",
+      "********************\n",
+      "\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "WARNING:tensorflow:Gradients do not exist for variables ['transformer_block/tfxl_net_model/transformer/mask_emb:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._0/rel_attn/seg_embed:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer_block/tfxl_net_model/transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss.\n",
+      "finished\n",
+      "2/2 [==============================] - 1s 550ms/step - eval_ndcg_at_1_1: 0.9942 - eval_ndcg_at_1_5: 0.9942 - eval_ndcg_at_1_20: 0.9942 - eval_ndcg_at_1_40: 0.9942 - eval_recall_at_1_1: 0.9424 - eval_recall_at_1_5: 0.9763 - eval_recall_at_1_20: 0.9942 - eval_recall_at_1_40: 0.9942 - loss: 0.4446 - regularization_loss: 0.0000e+00 - total_loss: 0.4446\n",
+      "********************\n",
+      "Eval results for day 3 are:\t\n",
+      "\n",
+      "********************\n",
+      "\n",
+      " eval_ndcg_at_1_1 = 1.0\n",
+      " eval_ndcg_at_1_20 = 1.0\n",
+      " eval_ndcg_at_1_40 = 1.0\n",
+      " eval_ndcg_at_1_5 = 1.0\n",
+      " eval_recall_at_1_1 = 0.9368420839309692\n",
+      " eval_recall_at_1_20 = 1.0\n",
+      " eval_recall_at_1_40 = 1.0\n",
+      " eval_recall_at_1_5 = 0.9789473414421082\n",
+      " loss = 0.4243243932723999\n",
+      " regularization_loss = 0\n",
+      " total_loss = 0.4243243932723999\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time_window_index = 1\n",
+    "final_time_window_index = 3\n",
+    "#Iterating over days of one week\n",
+    "for time_index in range(start_time_window_index, final_time_window_index):\n",
+    "    # Set data \n",
+    "    time_index_train = time_index\n",
+    "    time_index_eval = time_index + 1\n",
+    "    train_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_train}/train.parquet\"))\n",
+    "    eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
+    "    print(train_paths)\n",
+    "\n",
+    "    # Train on day related to time_index \n",
+    "    print('*'*20)\n",
+    "    print(\"Launch training for day %s are:\" %time_index)\n",
+    "    print('*'*20 + '\\n')\n",
+    "    train_loader = get_dataloader(train_paths) \n",
+    "    losses = model.fit(train_loader, epochs=5, verbose=0, )\n",
+    "    model.reset_metrics()\n",
+    "    print('finished')\n",
+    "    # Evaluate on the following day\n",
+    "    eval_loader = get_dataloader(eval_paths) \n",
+    "    eval_metrics = model.evaluate(eval_loader, return_dict=True)\n",
+    "    print('*'*20)\n",
+    "    print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
+    "    print('\\n' + '*'*20 + '\\n')\n",
+    "    for key in sorted(eval_metrics.keys()):\n",
+    "        print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "709c4dbc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2/2 [==============================] - 1s 541ms/step - eval_ndcg_at_1_1: 0.9900 - eval_ndcg_at_1_5: 0.9900 - eval_ndcg_at_1_20: 0.9900 - eval_ndcg_at_1_40: 0.9900 - eval_recall_at_1_1: 0.9700 - eval_recall_at_1_5: 0.9721 - eval_recall_at_1_20: 0.9900 - eval_recall_at_1_40: 0.9900 - loss: 0.3703 - regularization_loss: 0.0000e+00 - total_loss: 0.3703\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Evaluate on the following day\n",
+    "time_index_eval = 5\n",
+    "eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
+    "eval_loader = get_dataloader(eval_paths) \n",
+    "eval_metrics = model.evaluate(eval_loader, return_dict=True, )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "a015626f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'eval_ndcg_at_1_1': 0.991304337978363,\n",
+       " 'eval_ndcg_at_1_5': 0.991304337978363,\n",
+       " 'eval_ndcg_at_1_20': 0.991304337978363,\n",
+       " 'eval_ndcg_at_1_40': 0.991304337978363,\n",
+       " 'eval_recall_at_1_1': 0.9739130139350891,\n",
+       " 'eval_recall_at_1_5': 0.9739130139350891,\n",
+       " 'eval_recall_at_1_20': 0.991304337978363,\n",
+       " 'eval_recall_at_1_40': 0.991304337978363,\n",
+       " 'loss': 0.36306288838386536,\n",
+       " 'regularization_loss': 0,\n",
+       " 'total_loss': 0.36306288838386536}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eval_metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d79271a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "********************\n",
+      "Eval results for day 5 are:\t\n",
+      "\n",
+      "********************\n",
+      "\n",
+      " eval_ndcg_at_1_1 = 0.991304337978363\n",
+      " eval_ndcg_at_1_20 = 0.991304337978363\n",
+      " eval_ndcg_at_1_40 = 0.991304337978363\n",
+      " eval_ndcg_at_1_5 = 0.991304337978363\n",
+      " eval_recall_at_1_1 = 0.9739130139350891\n",
+      " eval_recall_at_1_20 = 0.991304337978363\n",
+      " eval_recall_at_1_40 = 0.991304337978363\n",
+      " eval_recall_at_1_5 = 0.9739130139350891\n",
+      " loss = 0.36306288838386536\n",
+      " regularization_loss = 0\n",
+      " total_loss = 0.36306288838386536\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('*'*20)\n",
+    "print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
+    "print('\\n' + '*'*20 + '\\n')\n",
+    "for key in sorted(eval_metrics.keys()):\n",
+    "    print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16181832",
+   "metadata": {},
+   "source": [
+    "### Saves the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8734a8ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:tensorflow:Skipping full serialization of Keras layer TFSharedEmbeddings(), because it is not built.\n",
+      "WARNING:tensorflow:Skipping full serialization of Keras layer Dropout(), because it is not built.\n",
+      "WARNING:tensorflow:Skipping full serialization of Keras layer Dropout(), because it is not built.\n",
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:tensorflow:Skipping full serialization of Keras layer TFSequenceSummary(), because it is not built.\n",
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:absl:Function `_wrapped_model` contains input name(s) category-list_trim, item_id-list_trim, timestamp/age_days-list_trim, timestamp/weekday/sin-list_trim with unsupported characters which will be renamed to category_list_trim, item_id_list_trim, timestamp_age_days_list_trim, timestamp_weekday_sin_list_trim in the SavedModel.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
+      "WARNING:absl:Found untraced functions such as sequential_block_1_layer_call_and_return_conditional_losses, sequential_block_1_layer_call_fn, next_item_prediction_task_layer_call_and_return_conditional_losses, next_item_prediction_task_layer_call_fn, sequential_block_1_layer_call_fn while saving (showing 5 of 205). These functions will not be directly callable after loading.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:tensorflow:Assets written to: tmp/tensorflow/assets\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:tensorflow:Assets written to: tmp/tensorflow/assets\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.save('tmp/tensorflow')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "004e1ca8",
+   "metadata": {},
+   "source": [
+    "### Reloads the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "46eb8249",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'layers'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_383189/1763871290.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mmodel\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkeras\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_model\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'./tmp/tensorflow'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/save.py\u001b[0m in \u001b[0;36mload_model\u001b[0;34m(filepath, custom_objects, compile, options)\u001b[0m\n\u001b[1;32m    203\u001b[0m         \u001b[0mfilepath\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpath_to_string\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    204\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 205\u001b[0;31m           \u001b[0;32mreturn\u001b[0m \u001b[0msaved_model_load\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcompile\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    206\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    207\u001b[0m   raise IOError(\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36mload\u001b[0;34m(path, compile, options)\u001b[0m\n\u001b[1;32m    132\u001b[0m   \u001b[0;31m# Recreate layers and metrics using the info stored in the metadata.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    133\u001b[0m   \u001b[0mkeras_loader\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mKerasObjectLoader\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmetadata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobject_graph_def\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 134\u001b[0;31m   \u001b[0mkeras_loader\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mload_layers\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcompile\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcompile\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    135\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    136\u001b[0m   \u001b[0;31m# Generate a dictionary of all loaded nodes.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36mload_layers\u001b[0;34m(self, compile)\u001b[0m\n\u001b[1;32m    392\u001b[0m         \u001b[0;32mcontinue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    393\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 394\u001b[0;31m       self.loaded_nodes[node_metadata.node_id] = self._load_layer(\n\u001b[0m\u001b[1;32m    395\u001b[0m           \u001b[0mnode_metadata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnode_id\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnode_metadata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0midentifier\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    396\u001b[0m           node_metadata.metadata)\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36m_load_layer\u001b[0;34m(self, node_id, identifier, metadata)\u001b[0m\n\u001b[1;32m    434\u001b[0m     \u001b[0;31m# Detect whether this object can be revived from the config. If not, then\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    435\u001b[0m     \u001b[0;31m# revive from the SavedModel instead.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 436\u001b[0;31m     \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msetter\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_revive_from_config\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0midentifier\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmetadata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnode_id\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    437\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mobj\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    438\u001b[0m       \u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msetter\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrevive_custom_object\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0midentifier\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmetadata\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36m_revive_from_config\u001b[0;34m(self, identifier, metadata, node_id)\u001b[0m\n\u001b[1;32m    452\u001b[0m       obj = (\n\u001b[1;32m    453\u001b[0m           \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_revive_graph_network\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0midentifier\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmetadata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnode_id\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 454\u001b[0;31m           self._revive_layer_or_model_from_config(metadata, node_id))\n\u001b[0m\u001b[1;32m    455\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    456\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mobj\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/saving/saved_model/load.py\u001b[0m in \u001b[0;36m_revive_layer_or_model_from_config\u001b[0;34m(self, metadata, node_id)\u001b[0m\n\u001b[1;32m    516\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    517\u001b[0m     \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 518\u001b[0;31m       obj = layers_module.deserialize(\n\u001b[0m\u001b[1;32m    519\u001b[0m           generic_utils.serialize_keras_class_and_config(\n\u001b[1;32m    520\u001b[0m               class_name, config, shared_object_id=shared_object_id))\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/layers/serialization.py\u001b[0m in \u001b[0;36mdeserialize\u001b[0;34m(config, custom_objects)\u001b[0m\n\u001b[1;32m    206\u001b[0m   \"\"\"\n\u001b[1;32m    207\u001b[0m   \u001b[0mpopulate_deserializable_objects\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 208\u001b[0;31m   return generic_utils.deserialize_keras_object(\n\u001b[0m\u001b[1;32m    209\u001b[0m       \u001b[0mconfig\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    210\u001b[0m       \u001b[0mmodule_objects\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mLOCAL\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mALL_OBJECTS\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/utils/generic_utils.py\u001b[0m in \u001b[0;36mdeserialize_keras_object\u001b[0;34m(identifier, module_objects, custom_objects, printable_module_name)\u001b[0m\n\u001b[1;32m    672\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    673\u001b[0m       \u001b[0;32mif\u001b[0m \u001b[0;34m'custom_objects'\u001b[0m \u001b[0;32min\u001b[0m \u001b[0marg_spec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 674\u001b[0;31m         deserialized_obj = cls.from_config(\n\u001b[0m\u001b[1;32m    675\u001b[0m             \u001b[0mcls_config\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    676\u001b[0m             custom_objects=dict(\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/engine/training.py\u001b[0m in \u001b[0;36mfrom_config\u001b[0;34m(cls, config, custom_objects)\u001b[0m\n\u001b[1;32m   2395\u001b[0m     \u001b[0;32mwith\u001b[0m \u001b[0mgeneric_utils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mSharedObjectLoadingScope\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2396\u001b[0m       input_tensors, output_tensors, created_layers = (\n\u001b[0;32m-> 2397\u001b[0;31m           functional.reconstruct_from_config(config, custom_objects))\n\u001b[0m\u001b[1;32m   2398\u001b[0m       \u001b[0;31m# Initialize a model belonging to `cls`, which can be user-defined or\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2399\u001b[0m       \u001b[0;31m# `Functional`.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/dist-packages/keras/engine/functional.py\u001b[0m in \u001b[0;36mreconstruct_from_config\u001b[0;34m(config, custom_objects, created_layers)\u001b[0m\n\u001b[1;32m   1270\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1271\u001b[0m   \u001b[0;31m# First, we create all layers and enqueue nodes to be processed\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1272\u001b[0;31m   \u001b[0;32mfor\u001b[0m \u001b[0mlayer_data\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mconfig\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'layers'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1273\u001b[0m     \u001b[0mprocess_layer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlayer_data\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1274\u001b[0m   \u001b[0;31m# Then we process nodes in order of layer depth.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'layers'"
+     ]
+    }
+   ],
+   "source": [
+    "model = tf.keras.models.load_model('./tmp/tensorflow')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0aa626c5",
+   "metadata": {},
+   "source": [
+    "### Re-compute eval metrics of validation data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaf8e7d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_data_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
+    "eval_loader = get_dataloader(eval_data_paths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ac1f859",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_metrics = model.evaluate(eval_loader)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4adff45e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for key in sorted(eval_metrics.keys()):\n",
+    "    print(\"  %s = %s\" % (key, str(eval_metrics[key])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0e2cdb2",
+   "metadata": {},
+   "source": [
+    "That's it!  \n",
+    "You have just trained your session-based recommendation model using Transformers4Rec."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3abd2856",
+   "metadata": {},
+   "source": [
+    "Tip: We can easily log and visualize model training and evaluation on [Weights & Biases (W&B)](https://wandb.ai/home), [Tensorboard](https://www.tensorflow.org/tensorboard) and [NVIDIA DLLogger](https://github.com/NVIDIA/dllogger). By default, the HuggingFace transformers `Trainer` (which we extend) uses Weights & Biases (W&B) to log training and evaluation metrics, which provides nice results visualization and comparison between different runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4645350",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.convert_to_tensor([0.5, 0.6])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40d48ffd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dict(zip(['top_5', 'top_6'], tf.convert_to_tensor([0.5, 0.6])))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f1ad652",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "7b543a88d374ac88bf8df97911b380f671b13649694a5b49eb21e60fd27eb479"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
+++ b/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
@@ -3,9 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "829d71e1",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# Copyright 2021 NVIDIA Corporation. All Rights Reserved.\n",
     "#\n",
@@ -21,93 +18,83 @@
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License.\n",
     "# =============================================================================="
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "95ebd562",
-   "metadata": {},
    "source": [
     "# Session-based Recommendation with XLNET"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "ee69e6c5",
-   "metadata": {},
    "source": [
     "In this notebook we introduce the [Transformers4Rec](https://github.com/NVIDIA-Merlin/Transformers4Rec) library for sequential and session-based recommendation. This notebook uses the PyTorch API, but a TensorFlow API is also available. Transformers4Rec integrates with the popular [HuggingFace’s Transformers](https://github.com/huggingface/transformers) and make it possible to experiment with cutting-edge implementation of the latest NLP Transformer architectures.  \n",
     "\n",
     "We demonstrate how to build a session-based recommendation model with the [XLNET](https://arxiv.org/abs/1906.08237) Transformer architecture. The XLNet architecture was designed to leverage the best of both auto-regressive language modeling and auto-encoding with its Permutation Language Modeling training method. In this example we will use XLNET with masked language modeling (MLM) training method, which showed very promising results in the experiments conducted in our [ACM RecSys'21 paper](https://github.com/NVIDIA-Merlin/publications/blob/main/2021_acm_recsys_transformers4rec/recsys21_transformers4rec_paper.pdf)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "1dc0f40a",
-   "metadata": {},
    "source": [
     "In the previous notebook we went through our ETL pipeline with NVTabular library, and created sequential features to be used in training a session-based recommendation model. In this notebook we will learn:\n",
     "\n",
     "- Accelerating data loading of parquet files with multiple features on PyTorch using NVTabular library\n",
     "- Training and evaluating a Transformer-based (XLNET-MLM) session-based recommendation model with multiple features"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "b2cfe10b",
-   "metadata": {},
    "source": [
     "## Build a DL model with Transformers4Rec library  "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "6d4ccc5b",
-   "metadata": {},
    "source": [
     "Transformers4Rec supports multiple input features and provides configurable building blocks that can be easily combined for custom architectures:\n",
     "\n",
-    "- [TabularSequenceFeatures](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.TabularSequenceFeatures) class that reads from schema and creates an input block. This input module combines different types of features (continuous, categorical & text) to a sequence.\n",
-    "-  [MaskSequence](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/torch/masking.py) to define masking schema and prepare the masked inputs and labels for the selected LM task.\n",
-    "-  [TransformerBlock](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.TransformerBlock) class that supports HuggingFace Transformers for session-based and sequential-based recommendation models.\n",
-    "-  [SequentialBlock](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.SequentialBlock) creates the body by mimicking [torch.nn.sequential](https://pytorch.org/docs/stable/generated/torch.nn.Sequential.html) class. It is designed to define our model as a sequence of layers.\n",
-    "-  [Head](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.Head) where we define the prediction task of the model.\n",
-    "-  [NextItemPredictionTask](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.NextItemPredictionTask) is the class to support next item prediction task.\n",
-    "- [Trainer](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.torch.html#transformers4rec.torch.Trainer) extends the `Trainer` class from HF transformers and manages the model training and evaluation.\n",
+    "- [TabularSequenceFeatures](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.torch.TabularSequenceFeatures) class that reads from schema and creates an input block. This input module combines different types of features (continuous, categorical & text) to a sequence.\n",
+    "-  [MaskSequence](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/masking.py) to define masking schema and prepare the masked inputs and labels for the selected LM task.\n",
+    "-  [TransformerBlock](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.torch.TransformerBlock) class that supports HuggingFace Transformers for session-based and sequential-based recommendation models.\n",
+    "-  [SequentialBlock](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.torch.SequentialBlock) creates the body by mimicking [tf.keras.Sequential](https://www.tensorflow.org/api_docs/python/tf/keras/Sequential) class. It is designed to define our model as a sequence of layers.\n",
+    "-  [Head](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.tf.Head) where we define the prediction task of the model.\n",
+    "-  [NextItemPredictionTask](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.tf.NextItemPredictionTask) is the class to support next item prediction task.\n",
     "\n",
     "You can check the [full documentation](https://nvidia-merlin.github.io/Transformers4Rec/main/index.html) of Transformers4Rec if needed."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "2fbdb9c8",
-   "metadata": {},
    "source": [
     "Figure 1 illustrates Transformers4Rec meta-architecture and how each module/block interacts with each other."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "396076b2",
-   "metadata": {},
    "source": [
     "![tf4rec_meta](images/tf4rec_meta2.png)"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "0e7eb33f",
-   "metadata": {},
    "source": [
     "### Imports required libraries"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "7f3330de",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import os\n",
     "import os\n",
@@ -118,46 +105,49 @@
     "\n",
     "from transformers4rec import tf as tr\n",
     "from transformers4rec.tf.ranking_metric import NDCGAt, AvgPrecisionAt, RecallAt"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e875b93d",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import cudf\n",
     "import dask_cudf\n",
     "from cudf.io.parquet import ParquetWriter as pwriter_cudf\n",
     "from dask_cudf.io.parquet import CudfEngine"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "abc20f09",
-   "metadata": {},
    "source": [
     "Transformers4Rec library relies on a schema object to automatically build all necessary layers to represent, normalize and aggregate input features. As you can see below, `schema.pb` is a protobuf file that contains metadata including statistics about features such as cardinality, min and max values and also tags features based on their characteristics and dtypes (e.g., categorical, continuous, list, integer)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "3da652df",
-   "metadata": {},
    "source": [
     "### Manually set the schema "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "0abd4957",
-   "metadata": {},
+   "source": [
+    "from merlin_standard_lib import Schema\n",
+    "SCHEMA_PATH = \"schema.pb\"\n",
+    "schema = Schema().from_proto_text(SCHEMA_PATH)\n",
+    "!cat $SCHEMA_PATH"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "feature {\n",
       "  name: \"session_id\"\n",
@@ -249,57 +239,45 @@
      ]
     }
    ],
-   "source": [
-    "from merlin_standard_lib import Schema\n",
-    "SCHEMA_PATH = \"schema.pb\"\n",
-    "schema = Schema().from_proto_text(SCHEMA_PATH)\n",
-    "!cat $SCHEMA_PATH"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8d5cc0e3",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# You can select a subset of features for training\n",
     "schema = schema.select_by_name(['item_id-list_trim', \n",
     "                                'category-list_trim', \n",
     "                                'timestamp/weekday/sin-list_trim',\n",
     "                                'timestamp/age_days-list_trim'])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "9a72110a",
-   "metadata": {},
    "source": [
     "### Define the sequential input module"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "62368d00",
-   "metadata": {},
    "source": [
     "Below we define our `input` block using the `TabularSequenceFeatures` [class](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/features/sequence.py#L121). The `from_schema()` method processes the schema and creates the necessary layers to represent features and aggregate them. It keeps only features tagged as `categorical` and `continuous` and supports data aggregation methods like `concat` and `elementwise-sum` techniques. It also support data augmentation techniques like stochastic swap noise. It outputs an interaction representation after combining all features and also the input mask according to the training task (more on this later).\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "f507e843",
-   "metadata": {},
    "source": [
     "The `max_sequence_length` argument defines the maximum sequence length of our sequential input, and if `continuous_projection` argument is set, all numerical features are concatenated and projected by an MLP block so that continuous features are represented by a vector of size defined by user, which is `64` in this example."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "030a4caf",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "inputs = tr.TabularSequenceFeatures.from_schema(\n",
     "        schema,\n",
@@ -308,12 +286,12 @@
     "        d_output=100,\n",
     "        masking=\"mlm\",\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "90acf861",
-   "metadata": {},
    "source": [
     "The output of the `TabularSequenceFeatures` module is the sequence of interactions embeddings vectors defined in the following steps:\n",
     "- 1. Create sequence inputs: If the schema contains non sequential features, expand each feature to a sequence by repeating the value as many as the `max_sequence_length` value.  \n",
@@ -321,34 +299,30 @@
     "- 3. Project scalar values if `continuous_projection` is set : Apply an MLP layer with hidden size equal to `continuous_projection` vector size value. The resulting tensor is of shape (batch_size, max_sequence_length, continuous_projection).\n",
     "- 4. Aggregate the list of features vectors to represent each interaction in the sequence with one vector: For example, `concat` will concat all vectors based on the last dimension `-1` and the resulting tensor will be of shape (batch_size, max_sequence_length, D) where D is the sum over all embedding dimensions and the value of continuous_projection. \n",
     "- 5. If masking schema is set (needed only for the NextItemPredictionTask training), the masked labels are derived from the sequence of raw item-ids and the sequence of interactions embeddings are processed to mask information about the masked positions."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "199e395f",
-   "metadata": {},
    "source": [
     "### Define the Transformer Block"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "a9b3b90d",
-   "metadata": {},
    "source": [
     "In the next cell, the whole model is build with a few lines of code. \n",
     "Here is a brief explanation of the main classes:  \n",
-    "- [XLNetConfig](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/config/transformer.py#L261) - We have injected in the HF transformers config classes like `XLNetConfig`the `build()` method, that provides default configuration to Transformer architectures for session-based recommendation. Here we use it to instantiate and configure an XLNET architecture.  \n",
+    "- [XLNetConfig](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/config/transformer.py#L261) - We have injected in the HF transformers config classes like `XLNetConfig` the `build()` method, that provides default configuration to Transformer architectures for session-based recommendation. Here we use it to instantiate and configure an XLNET architecture.  \n",
     "- [TransformerBlock](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/block/transformer.py#L42) class integrates with HF Transformers, which are made available as a sequence processing module for session-based and sequential-based recommendation models.  \n",
     "- [NextItemPredictionTask](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/405e3142f1274b1b0d642f4834ac437f2549cd33/transformers4rec/tf/model/prediction_task.py#82) supports the next-item prediction task. We also support other predictions [tasks](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/model/prediction_task.py), like classification and regression for the whole sequence. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c8d3ef7a",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# Define XLNetConfig class and set default parameters for HF XLNet config  \n",
     "transformer_config = tr.XLNetConfig.build(\n",
@@ -369,38 +343,34 @@
     "task = tr.NextItemPredictionTask(weight_tying=True, metrics=metrics)\n",
     " \n",
     "model = task.to_model(body=body)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "ad1b5657",
-   "metadata": {},
    "source": [
     "### Train the model "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "a0b46cc2",
-   "metadata": {},
    "source": [
     "We use the NVTabular `KerasSequenceLoader` Dataloader for optimized loading of multiple features from input parquet files. You can learn more about this data loader [here](https://nvidia-merlin.github.io/NVTabular/main/training/tensorflow.html)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "7653df09",
-   "metadata": {},
    "source": [
     "### **Set DataLoader**"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "dc3f631c",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "x_cat_names, x_cont_names = ['category-list_trim', 'item_id-list_trim'], ['timestamp/age_days-list_trim', 'timestamp/weekday/sin-list_trim']\n",
     "\n",
@@ -422,22 +392,20 @@
     "        sparse_as_dense=True,\n",
     "    )\n",
     "    return dataloader.map(lambda X, y: (X, []))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "94ddd25f",
-   "metadata": {},
    "source": [
     "## Set training params"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "d9ebc653",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import tensorflow as tf\n",
     "lr_schedule = tf.keras.optimizers.schedules.CosineDecay(\n",
@@ -445,62 +413,86 @@
     "    decay_steps=1.5)\n",
     "optimizer = tf.keras.optimizers.Adam(learning_rate=lr_schedule)\n",
     "model.compile(optimizer=\"adam\", run_eagerly=True)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "67175c07",
-   "metadata": {},
    "source": [
     "## Daily Fine-Tuning: Training over a time window"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "d86c2575",
-   "metadata": {},
    "source": [
     "Here we do daily fine-tuning meaning that we use the first day to train and second day to evaluate, then we use the second day data to train the model by resuming from the first step, and evaluate on the third day, so on so forth."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "7484df73",
-   "metadata": {},
    "source": [
     "- Define the output folder of the processed parquet files"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "80bed8a3",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "OUTPUT_DIR = os.environ.get(\"OUTPUT_DIR\", \"/workspace/data/sessions_by_day\")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "ceb428a0",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import warnings\n",
     "warnings.filterwarnings('ignore')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "fb812e2d",
-   "metadata": {},
+   "source": [
+    "start_time_window_index = 1\n",
+    "final_time_window_index = 3\n",
+    "#Iterating over days of one week\n",
+    "for time_index in range(start_time_window_index, final_time_window_index):\n",
+    "    # Set data \n",
+    "    time_index_train = time_index\n",
+    "    time_index_eval = time_index + 1\n",
+    "    train_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_train}/train.parquet\"))\n",
+    "    eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
+    "    print(train_paths)\n",
+    "\n",
+    "    # Train on day related to time_index \n",
+    "    print('*'*20)\n",
+    "    print(\"Launch training for day %s are:\" %time_index)\n",
+    "    print('*'*20 + '\\n')\n",
+    "    train_loader = get_dataloader(train_paths) \n",
+    "    losses = model.fit(train_loader, epochs=5, verbose=0, )\n",
+    "    model.reset_metrics()\n",
+    "    print('finished')\n",
+    "    # Evaluate on the following day\n",
+    "    eval_loader = get_dataloader(eval_paths) \n",
+    "    eval_metrics = model.evaluate(eval_loader, return_dict=True)\n",
+    "    print('*'*20)\n",
+    "    print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
+    "    print('\\n' + '*'*20 + '\\n')\n",
+    "    for key in sorted(eval_metrics.keys()):\n",
+    "        print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "['/workspace/data/sessions_by_day/1/train.parquet']\n",
       "********************\n",
@@ -701,65 +693,38 @@
      ]
     }
    ],
-   "source": [
-    "start_time_window_index = 1\n",
-    "final_time_window_index = 3\n",
-    "#Iterating over days of one week\n",
-    "for time_index in range(start_time_window_index, final_time_window_index):\n",
-    "    # Set data \n",
-    "    time_index_train = time_index\n",
-    "    time_index_eval = time_index + 1\n",
-    "    train_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_train}/train.parquet\"))\n",
-    "    eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
-    "    print(train_paths)\n",
-    "\n",
-    "    # Train on day related to time_index \n",
-    "    print('*'*20)\n",
-    "    print(\"Launch training for day %s are:\" %time_index)\n",
-    "    print('*'*20 + '\\n')\n",
-    "    train_loader = get_dataloader(train_paths) \n",
-    "    losses = model.fit(train_loader, epochs=5, verbose=0, )\n",
-    "    model.reset_metrics()\n",
-    "    print('finished')\n",
-    "    # Evaluate on the following day\n",
-    "    eval_loader = get_dataloader(eval_paths) \n",
-    "    eval_metrics = model.evaluate(eval_loader, return_dict=True)\n",
-    "    print('*'*20)\n",
-    "    print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
-    "    print('\\n' + '*'*20 + '\\n')\n",
-    "    for key in sorted(eval_metrics.keys()):\n",
-    "        print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "709c4dbc",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2/2 [==============================] - 1s 541ms/step - eval_ndcg_at_1_1: 0.9900 - eval_ndcg_at_1_5: 0.9900 - eval_ndcg_at_1_20: 0.9900 - eval_ndcg_at_1_40: 0.9900 - eval_recall_at_1_1: 0.9700 - eval_recall_at_1_5: 0.9721 - eval_recall_at_1_20: 0.9900 - eval_recall_at_1_40: 0.9900 - loss: 0.3703 - regularization_loss: 0.0000e+00 - total_loss: 0.3703\n"
-     ]
-    }
-   ],
    "source": [
     "# Evaluate on the following day\n",
     "time_index_eval = 5\n",
     "eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
     "eval_loader = get_dataloader(eval_paths) \n",
     "eval_metrics = model.evaluate(eval_loader, return_dict=True, )"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "2/2 [==============================] - 1s 541ms/step - eval_ndcg_at_1_1: 0.9900 - eval_ndcg_at_1_5: 0.9900 - eval_ndcg_at_1_20: 0.9900 - eval_ndcg_at_1_40: 0.9900 - eval_recall_at_1_1: 0.9700 - eval_recall_at_1_5: 0.9721 - eval_recall_at_1_20: 0.9900 - eval_recall_at_1_40: 0.9900 - loss: 0.3703 - regularization_loss: 0.0000e+00 - total_loss: 0.3703\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "a015626f",
-   "metadata": {},
+   "source": [
+    "eval_metrics"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'eval_ndcg_at_1_1': 0.991304337978363,\n",
@@ -775,24 +740,26 @@
        " 'total_loss': 0.36306288838386536}"
       ]
      },
-     "execution_count": 14,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 14
     }
    ],
-   "source": [
-    "eval_metrics"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "d79271a2",
-   "metadata": {},
+   "source": [
+    "print('*'*20)\n",
+    "print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
+    "print('\\n' + '*'*20 + '\\n')\n",
+    "for key in sorted(eval_metrics.keys()):\n",
+    "    print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "********************\n",
       "Eval results for day 5 are:\t\n",
@@ -813,31 +780,25 @@
      ]
     }
    ],
-   "source": [
-    "print('*'*20)\n",
-    "print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
-    "print('\\n' + '*'*20 + '\\n')\n",
-    "for key in sorted(eval_metrics.keys()):\n",
-    "    print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "16181832",
-   "metadata": {},
    "source": [
     "### Saves the model"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "8734a8ae",
-   "metadata": {},
+   "source": [
+    "model.save('tmp/tensorflow')"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n",
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
@@ -860,386 +821,384 @@
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:absl:Function `_wrapped_model` contains input name(s) category-list_trim, item_id-list_trim, timestamp/age_days-list_trim, timestamp/weekday/sin-list_trim with unsupported characters which will be renamed to category_list_trim, item_id_list_trim, timestamp_age_days_list_trim, timestamp_weekday_sin_list_trim in the SavedModel.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:The parameters `output_attentions`, `output_hidden_states` and `use_cache` cannot be updated when calling a model.They have to be set to True/False in the config object (i.e.: `config=XConfig.from_pretrained('name', output_attentions=True)`).\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "WARNING:tensorflow:The parameter `return_dict` cannot be set in graph mode and will always be set to `True`.\n",
       "WARNING:absl:Found untraced functions such as sequential_block_1_layer_call_and_return_conditional_losses, sequential_block_1_layer_call_fn, next_item_prediction_task_layer_call_and_return_conditional_losses, next_item_prediction_task_layer_call_fn, sequential_block_1_layer_call_fn while saving (showing 5 of 205). These functions will not be directly callable after loading.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "INFO:tensorflow:Assets written to: tmp/tensorflow/assets\n"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "INFO:tensorflow:Assets written to: tmp/tensorflow/assets\n"
      ]
     }
    ],
-   "source": [
-    "model.save('tmp/tensorflow')"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "004e1ca8",
-   "metadata": {},
    "source": [
     "### Reloads the model"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "46eb8249",
-   "metadata": {},
+   "source": [
+    "model = tf.keras.models.load_model('./tmp/tensorflow')"
+   ],
    "outputs": [
     {
+     "output_type": "error",
      "ename": "KeyError",
      "evalue": "'layers'",
-     "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
@@ -1258,94 +1217,83 @@
      ]
     }
    ],
-   "source": [
-    "model = tf.keras.models.load_model('./tmp/tensorflow')"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "0aa626c5",
-   "metadata": {},
    "source": [
     "### Re-compute eval metrics of validation data"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aaf8e7d3",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "eval_data_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
     "eval_loader = get_dataloader(eval_data_paths)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ac1f859",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "eval_metrics = model.evaluate(eval_loader)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4adff45e",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "for key in sorted(eval_metrics.keys()):\n",
     "    print(\"  %s = %s\" % (key, str(eval_metrics[key])))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "f0e2cdb2",
-   "metadata": {},
    "source": [
     "That's it!  \n",
     "You have just trained your session-based recommendation model using Transformers4Rec."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "3abd2856",
-   "metadata": {},
    "source": [
     "Tip: We can easily log and visualize model training and evaluation on [Weights & Biases (W&B)](https://wandb.ai/home), [Tensorboard](https://www.tensorflow.org/tensorboard) and [NVIDIA DLLogger](https://github.com/NVIDIA/dllogger). By default, the HuggingFace transformers `Trainer` (which we extend) uses Weights & Biases (W&B) to log training and evaluation metrics, which provides nice results visualization and comparison between different runs."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4645350",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "tf.convert_to_tensor([0.5, 0.6])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40d48ffd",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "dict(zip(['top_5', 'top_6'], tf.convert_to_tensor([0.5, 0.6])))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f1ad652",
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 numpy>=1.17.0
-transformers==4.*
+transformers==4.11.*
 tqdm>=4.27
 betterproto<2.0.0
 pyarrow>=1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 numpy>=1.17.0
-transformers==4.9.*
+transformers==4.*
 tqdm>=4.27
 betterproto<2.0.0
 pyarrow>=1.0

--- a/tests/tf/model/test_model.py
+++ b/tests/tf/model/test_model.py
@@ -165,7 +165,7 @@ def test_next_item_fit(tf_yoochoose_like, yoochoose_schema, masking, run_eagerly
     losses = model.fit(dataset, epochs=5)
     metrics = model.evaluate(tf_yoochoose_like, tf_yoochoose_like["item_id/list"], return_dict=True)
 
-    assert len(metrics.keys()) == 6
+    assert len(metrics.keys()) == 9
     assert len(losses.epoch) == 5
     assert all(loss >= 0 for loss in losses.history["loss"])
     assert losses.history["loss"][-1] < losses.history["loss"][0]

--- a/tests/tf/model/test_model.py
+++ b/tests/tf/model/test_model.py
@@ -47,7 +47,8 @@ def test_simple_model(tf_tabular_features, tf_tabular_data, run_eagerly):
     model._set_inputs(inputs)
     with tempfile.TemporaryDirectory() as tmpdir:
         model.save(tmpdir, include_optimizer=False)
-        model = tf.keras.models.load_model(tmpdir)
+        custom_objects = {"Model": tr.model.base.Model}
+        model = tf.keras.models.load_model(tmpdir, custom_objects=custom_objects)
 
 
 def test_simple_seq_classification(yoochoose_schema, tf_yoochoose_like):
@@ -209,8 +210,9 @@ def test_save_load_item_prediction(yoochoose_schema, tf_yoochoose_like, masking,
     model._set_inputs(inputs)
     with tempfile.TemporaryDirectory() as tmpdir:
         model.save(tmpdir, include_optimizer=False)
-        custom_metrics = dict([(e.__class__.__name__, e) for e in task.metrics])
-        model = tf.keras.models.load_model(tmpdir, custom_objects=custom_metrics)
+        custom_objects = dict([(e.__class__.__name__, e) for e in task.metrics])
+        custom_objects.update({"Model": tr.model.base.Model})
+        model = tf.keras.models.load_model(tmpdir, custom_objects=custom_objects)
 
     assert tf.shape(model(inputs))[1] == 51997
 
@@ -262,7 +264,8 @@ def test_save_load_transformer_model(
     model._set_inputs(inputs)
     with tempfile.TemporaryDirectory() as tmpdir:
         model.save(tmpdir)
-        custom_metrics = dict([(e.__class__.__name__, e) for e in task.metrics])
-        model = tf.keras.models.load_model(tmpdir, custom_objects=custom_metrics)
+        custom_objects = dict([(e.__class__.__name__, e) for e in task.metrics])
+        custom_objects.update({"Model": tr.model.base.Model})
+        model = tf.keras.models.load_model(tmpdir, custom_objects=custom_objects)
 
     assert tf.shape(model(inputs))[1] == 51997

--- a/tests/tf/model/test_model.py
+++ b/tests/tf/model/test_model.py
@@ -140,13 +140,14 @@ def test_next_item_fit(tf_yoochoose_like, yoochoose_schema, masking, run_eagerly
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_save_model(yoochoose_schema, tf_yoochoose_like, run_eagerly):
+@pytest.mark.parametrize("masking", ["causal", "mlm"])
+def test_save_model(yoochoose_schema, tf_yoochoose_like, run_eagerly, masking):
     input_module = tr.TabularSequenceFeatures.from_schema(
         yoochoose_schema,
         max_sequence_length=20,
         continuous_projection=64,
         d_output=64,
-        masking="causal",
+        masking=masking,
     )
 
     body = tr.SequentialBlock([input_module, tr.MLPBlock([64])])

--- a/tests/tf/tabular/test_transformations.py
+++ b/tests/tf/tabular/test_transformations.py
@@ -77,7 +77,7 @@ def test_stochastic_swap_noise_with_tabular_features(
         replacement_rate = tf.reduce_mean(
             tf.cast(replaced_mask_non_padded, dtype=tf.float32)
         ).numpy()
-        assert replacement_rate == pytest.approx(replacement_prob, abs=0.15)
+        assert replacement_rate == pytest.approx(replacement_prob, abs=0.20)
 
 
 def test_stochastic_swap_noise_raise_exception_not_2d_item_id():

--- a/tests/tf/test_masking.py
+++ b/tests/tf/test_masking.py
@@ -28,8 +28,8 @@ lm_tasks = list(tr.masking.masking_registry.keys())
 def test_task_output_shape(tf_masking_inputs, task):
     lm = tr.masking.masking_registry[task](padding_idx=tf_masking_inputs["padding_idx"])
     out = lm(tf_masking_inputs["input_tensor"], tf_masking_inputs["labels"], training=True)
-    assert lm.masked_targets.shape[0] == tf_masking_inputs["input_tensor"].shape[0]
-    assert lm.masked_targets.shape[1] == tf_masking_inputs["input_tensor"].shape[1]
+    assert tf.shape(lm.masked_targets)[0] == tf_masking_inputs["input_tensor"].shape[0]
+    assert tf.shape(lm.masked_targets)[1] == tf_masking_inputs["input_tensor"].shape[1]
     assert out.shape[2] == tf_masking_inputs["input_tensor"].shape[2]
 
 

--- a/tests/tf/test_ranking_metrics.py
+++ b/tests/tf/test_ranking_metrics.py
@@ -32,7 +32,7 @@ def test_metrics_shape(tf_ranking_metrics_inputs, metric):
         y_pred=tf_ranking_metrics_inputs["scores"],
         y_true=tf_ranking_metrics_inputs["labels_one_hot"],
     )
-    assert result.shape[0] == len(tf_ranking_metrics_inputs["ks"])
+    assert tf.shape(result)[0] == len(tf_ranking_metrics_inputs["ks"])
 
 
 # Test label one hot encoding

--- a/tests/tf/test_ranking_metrics.py
+++ b/tests/tf/test_ranking_metrics.py
@@ -48,6 +48,15 @@ def test_score_with_transform_onehot(tf_ranking_metrics_inputs, metric):
     assert len(result) == len(tf_ranking_metrics_inputs["ks"])
 
 
+@pytest.mark.parametrize("metric", list_metrics)
+def test_score_different_from_zero(tf_ranking_metrics_inputs, metric):
+    metric = tr.ranking_metric.ranking_metrics_registry[metric](top_ks=[20], labels_onehot=True)
+    result = metric(
+        y_pred=tf_ranking_metrics_inputs["scores"], y_true=tf_ranking_metrics_inputs["labels"]
+    )
+    assert all(e > 0 for e in result)
+
+
 # compare implemented metrics w.r.t tensorflow_ranking
 metrics_to_compare = [
     (tfr.keras.metrics.RecallMetric, "recall"),

--- a/tests/tf/test_ranking_metrics.py
+++ b/tests/tf/test_ranking_metrics.py
@@ -26,8 +26,9 @@ list_metrics = list(tr.ranking_metric.ranking_metrics_registry.keys())
 # Test length of output equal to number of cutoffs
 @pytest.mark.parametrize("metric", list_metrics)
 def test_metrics_shape(tf_ranking_metrics_inputs, metric):
-    metric = tr.ranking_metric.ranking_metrics_registry[metric]
-    metric.top_ks = tf_ranking_metrics_inputs["ks"]
+    metric = tr.ranking_metric.ranking_metrics_registry[metric](
+        top_ks=tf_ranking_metrics_inputs["ks"]
+    )
     result = metric(
         y_pred=tf_ranking_metrics_inputs["scores"],
         y_true=tf_ranking_metrics_inputs["labels_one_hot"],
@@ -38,9 +39,9 @@ def test_metrics_shape(tf_ranking_metrics_inputs, metric):
 # Test label one hot encoding
 @pytest.mark.parametrize("metric", list_metrics)
 def test_score_with_transform_onehot(tf_ranking_metrics_inputs, metric):
-    metric = tr.ranking_metric.ranking_metrics_registry[metric]
-    metric.top_ks = tf_ranking_metrics_inputs["ks"]
-    metric.labels_onehot = True
+    metric = tr.ranking_metric.ranking_metrics_registry[metric](
+        top_ks=tf_ranking_metrics_inputs["ks"], labels_onehot=True
+    )
     result = metric(
         y_pred=tf_ranking_metrics_inputs["scores"], y_true=tf_ranking_metrics_inputs["labels"]
     )
@@ -67,8 +68,10 @@ def test_compare_with_tfr(tf_ranking_metrics_inputs, metric):
         for metric in tfr_metric
     ]
 
-    tr_metric = tr.ranking_metric.ranking_metrics_registry[metric[1]]
-    tr_metric.top_ks = tf_ranking_metrics_inputs["ks"]
+    tr_metric = tr.ranking_metric.ranking_metrics_registry[metric[1]](
+        top_ks=tf_ranking_metrics_inputs["ks"]
+    )
+
     results_tr = tr_metric(
         y_pred=tf_ranking_metrics_inputs["scores"],
         y_true=tf_ranking_metrics_inputs["labels_one_hot"],

--- a/tests/torch/block/test_transformer.py
+++ b/tests/torch/block/test_transformer.py
@@ -29,6 +29,7 @@ config_classes = [
     tconf.BertConfig,
     tconf.RobertaConfig,
     tconf.TransfoXLConfig,
+    tconf.AlbertConfig,
 ]
 
 # fixed parameters for tests

--- a/tests/torch/features/test_embedding.py
+++ b/tests/torch/features/test_embedding.py
@@ -184,7 +184,7 @@ def test_soft_embedding():
     ), "Soft embedding output has not the expected shape"
 
     # Checking the default embedding initialization
-    assert output.detach().numpy().mean() == pytest.approx(0.0, abs=0.1)
+    assert output.detach().numpy().mean() == pytest.approx(0.0, abs=0.2)
     assert output.detach().numpy().std() == pytest.approx(0.05, abs=0.2)
 
 

--- a/transformers4rec/tf/block/transformer.py
+++ b/transformers4rec/tf/block/transformer.py
@@ -23,6 +23,7 @@ from transformers import PretrainedConfig, TFPreTrainedModel
 
 from ...config.transformer import T4RecConfig, transformer_registry
 from ..masking import MaskSequence
+from ..utils.tf_utils import maybe_deserialize_keras_objects, maybe_serialize_keras_objects
 from .base import Block
 
 TransformerBody = Union[TFPreTrainedModel, PretrainedConfig]
@@ -94,6 +95,20 @@ class TransformerBlock(Block):
         if prepare_module:
             self.prepare_module = prepare_module(transformer, masking)
         self.output_fn = output_fn
+
+    def get_config(self):
+        config = super().get_config()
+        config = maybe_serialize_keras_objects(
+            self, config, ["transformer", "output_fn", "prepare_module", "masking"]
+        )
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        config = maybe_deserialize_keras_objects(
+            config, ["transformer", "output_fn", "prepare_module", "masking"]
+        )
+        return super().from_config(config)
 
     @classmethod
     def from_registry(

--- a/transformers4rec/tf/block/transformer.py
+++ b/transformers4rec/tf/block/transformer.py
@@ -156,9 +156,8 @@ class TransformerBlock(Block):
             if param in transformer_kwargs:
                 filtered_transformer_kwargs[param] = transformer_kwargs[param]
 
-        # In Keras the first (inputs) arg always needs to be set, therefore we supply the
-        # transformer_kwargs both as arg and **kwargs
-        model_outputs = self.transformer(transformer_kwargs, **filtered_transformer_kwargs)
+        # In HF the call accept inputs as a dictionnary contaning all needed tensors
+        model_outputs = self.transformer(filtered_transformer_kwargs)
         outputs = self.output_fn(model_outputs)
 
         # TODO: store the attention outputs for meta-data logging

--- a/transformers4rec/tf/masking.py
+++ b/transformers4rec/tf/masking.py
@@ -74,6 +74,17 @@ class MaskSequence(tf.keras.layers.Layer):
         self.mask_schema = None
         self.masked_targets = None
 
+    def get_config(self):
+        config = super(MaskSequence, self).get_config()
+        config.update(
+            {
+                "padding_idx": self.padding_idx,
+                "eval_on_last_item_seq_only": self.eval_on_last_item_seq_only,
+            }
+        )
+
+        return config
+
     def _compute_masked_targets(self, item_ids: tf.Tensor, training=False) -> MaskingInfo:
         """
         Method to prepare masked labels based on the sequence of item ids.
@@ -224,28 +235,47 @@ class CausalLanguageModeling(MaskSequence):
             padding_idx=padding_idx, eval_on_last_item_seq_only=eval_on_last_item_seq_only, **kwargs
         )
         self.train_on_last_item_seq_only = train_on_last_item_seq_only
+        self.label_seq_trg_eval = tf.Variable(
+            tf.zeros(shape=[1, 1], dtype=tf.int32),
+            dtype=tf.int32,
+            trainable=False,
+            shape=tf.TensorShape([None, None]),
+        )
+
+    def get_config(self):
+        config = super(CausalLanguageModeling, self).get_config()
+        config.update(
+            {
+                "train_on_last_item_seq_only": self.train_on_last_item_seq_only,
+            }
+        )
+        return config
 
     def _compute_masked_targets(self, item_ids: tf.Tensor, training=False) -> MaskingInfo:
+        item_ids = tf.cast(item_ids, dtype=tf.int32)
         masking_info: MaskingInfo = self.predict_all(item_ids)
         mask_labels, labels = masking_info.schema, masking_info.targets
 
         if (self.eval_on_last_item_seq_only and not training) or (
             self.train_on_last_item_seq_only and training
         ):
-            rows_ids = tf.range(tf.shape(labels)[0], dtype=item_ids.dtype)
-            label_seq_trg_eval = tf.zeros(tf.shape(labels), dtype=labels.dtype)
             last_item_sessions = tf.reduce_sum(tf.cast(mask_labels, labels.dtype), axis=1) - 1
+
+            rows_ids = tf.range(tf.shape(labels)[0], dtype=labels.dtype)
+            self.label_seq_trg_eval.assign(tf.zeros(tf.shape(labels), dtype=tf.int32))
+
             indices = tf.concat(
                 [tf.expand_dims(rows_ids, 1), tf.expand_dims(last_item_sessions, 1)], axis=1
             )
-            label_seq_trg_eval = tf.tensor_scatter_nd_update(
-                label_seq_trg_eval, indices=indices, updates=tf.gather_nd(labels, indices)
+            self.label_seq_trg_eval.scatter_nd_update(
+                indices=indices, updates=tf.gather_nd(labels, indices)
             )
             # Updating labels and mask
-            mask_labels = label_seq_trg_eval != self.padding_idx
-            labels = label_seq_trg_eval
+            mask_labels = self.label_seq_trg_eval != self.padding_idx
+        else:
+            self.label_seq_trg_eval.assign(labels)
 
-        return MaskingInfo(mask_labels, labels)
+        return MaskingInfo(mask_labels, self.label_seq_trg_eval)
 
     def apply_mask_to_inputs(self, inputs: tf.Tensor, mask_schema: tf.Tensor) -> tf.Tensor:
         # shift sequence of interaction embeddings
@@ -299,6 +329,21 @@ class MaskedLanguageModeling(MaskSequence):
             padding_idx=padding_idx, eval_on_last_item_seq_only=eval_on_last_item_seq_only, **kwargs
         )
         self.mlm_probability = mlm_probability
+        self.labels = tf.Variable(
+            tf.zeros(shape=[1, 1], dtype=tf.int32),
+            dtype=tf.int32,
+            trainable=False,
+            shape=tf.TensorShape([None, None]),
+        )
+
+    def get_config(self):
+        config = super(MaskedLanguageModeling, self).get_config()
+        config.update(
+            {
+                "mlm_probability": self.mlm_probability,
+            }
+        )
+        return config
 
     def _compute_masked_targets(self, item_ids: tf.Tensor, training: bool = False) -> MaskingInfo:
         """
@@ -317,24 +362,28 @@ class MaskedLanguageModeling(MaskSequence):
         mask_labels: tf.Tensor
             Masking schema for masked targets positions.
         """
+        # cast item_ids to int32
+        item_ids = tf.cast(item_ids, dtype=tf.int32)
+        self.labels.assign(tf.fill(tf.shape(item_ids), self.padding_idx))
 
-        labels = tf.cast(tf.fill(tf.shape(item_ids), self.padding_idx), dtype=item_ids.dtype)
-        non_padded_mask = tf.cast(item_ids != self.padding_idx, labels.dtype)
-        rows_ids = tf.range(tf.shape(labels)[0], dtype=tf.int64)
+        non_padded_mask = tf.cast(item_ids != self.padding_idx, self.labels.dtype)
+        rows_ids = tf.range(tf.shape(item_ids)[0], dtype=tf.int64)
         # During training, masks labels to be predicted according to a probability, ensuring that
         #   each session has at least one label to predict
         if training:
             # Selects a percentage of items to be masked (selected as labels)
             probability_matrix = tf.cast(
-                backend.random_bernoulli(array_ops.shape(labels), p=self.mlm_probability),
-                labels.dtype,
+                backend.random_bernoulli(array_ops.shape(item_ids), p=self.mlm_probability),
+                self.labels.dtype,
             )
 
             mask_labels = probability_matrix * non_padded_mask
-            labels = tf.where(
-                tf.cast(mask_labels, tf.bool),
-                item_ids,
-                tf.cast(tf.fill(tf.shape(item_ids), self.padding_idx), dtype=item_ids.dtype),
+            self.labels.assign(
+                tf.where(
+                    tf.cast(mask_labels, tf.bool),
+                    item_ids,
+                    tf.cast(tf.fill(tf.shape(item_ids), self.padding_idx), dtype=item_ids.dtype),
+                )
             )
 
             # Set at least one item in the sequence to mask, so that the network
@@ -343,10 +392,8 @@ class MaskedLanguageModeling(MaskSequence):
                 tf.math.log(tf.cast(non_padded_mask, tf.float32)), num_samples=1
             )
             indices = tf.concat([tf.expand_dims(rows_ids, 1), one_random_index_by_session], axis=1)
-            labels = tf.tensor_scatter_nd_update(
-                labels, indices=indices, updates=tf.gather_nd(item_ids, indices)
-            )
-            mask_labels = tf.cast(labels != self.padding_idx, labels.dtype)
+            self.labels.scatter_nd_update(indices=indices, updates=tf.gather_nd(item_ids, indices))
+            mask_labels = tf.cast(self.labels != self.padding_idx, self.labels.dtype)
 
             # If a sequence has only masked labels, unmask one of the labels
             sequences_with_only_labels = tf.reduce_sum(mask_labels, axis=1) == tf.reduce_sum(
@@ -360,10 +407,10 @@ class MaskedLanguageModeling(MaskSequence):
             rows_to_unmask = tf.boolean_mask(rows_ids, sequences_with_only_labels)
             indices = tf.concat([tf.expand_dims(rows_to_unmask, 1), labels_to_unmask], axis=1)
             num_updates = tf.shape(indices)[0]
-            labels = tf.tensor_scatter_nd_update(
-                labels, indices, tf.cast(tf.fill((num_updates,), self.padding_idx), labels.dtype)
+            self.labels.scatter_nd_update(
+                indices, tf.cast(tf.fill((num_updates,), self.padding_idx), self.labels.dtype)
             )
-            mask_labels = labels != self.padding_idx
+            mask_labels = self.labels != self.padding_idx
 
         else:
             if self.eval_on_last_item_seq_only:
@@ -376,15 +423,16 @@ class MaskedLanguageModeling(MaskSequence):
                     ],
                     axis=1,
                 )
-                labels = tf.tensor_scatter_nd_update(
-                    labels, indices=indices, updates=tf.gather_nd(item_ids, indices)
+                self.labels.scatter_nd_update(
+                    indices=indices, updates=tf.gather_nd(item_ids, indices)
                 )
-                mask_labels = labels != self.padding_idx
+                mask_labels = self.labels != self.padding_idx
             else:
                 masking_info = self.predict_all(item_ids)
                 mask_labels, labels = masking_info.schema, masking_info.targets
+                self.labels.assign(labels)
 
-        return MaskingInfo(mask_labels, labels)
+        return MaskingInfo(mask_labels, self.labels)
 
 
 # @masking_registry.register_with_multiple_names("plm", "permutation")

--- a/transformers4rec/tf/masking.py
+++ b/transformers4rec/tf/masking.py
@@ -44,6 +44,7 @@ class MaskingInfo:
 
 
 @docstring_parameter(mask_sequence_parameters=MASK_SEQUENCE_PARAMETERS_DOCSTRING)
+@tf.keras.utils.register_keras_serializable(package="merlin_models")
 class MaskSequence(tf.keras.layers.Layer):
     """Base class to prepare masked items inputs/labels for language modeling tasks.
 
@@ -213,6 +214,7 @@ class MaskSequence(tf.keras.layers.Layer):
 
 @masking_registry.register_with_multiple_names("clm", "causal")
 @docstring_parameter(mask_sequence_parameters=MASK_SEQUENCE_PARAMETERS_DOCSTRING)
+@tf.keras.utils.register_keras_serializable(package="merlin_models")
 class CausalLanguageModeling(MaskSequence):
     """
     In Causal Language Modeling (clm) you predict the next item based on past positions of the
@@ -301,6 +303,7 @@ class CausalLanguageModeling(MaskSequence):
 
 
 @masking_registry.register_with_multiple_names("mlm", "masked")
+@tf.keras.utils.register_keras_serializable(package="merlin_models")
 class MaskedLanguageModeling(MaskSequence):
     """
     In Masked Language Modeling (mlm) you randomly select some positions of the sequence to be

--- a/transformers4rec/tf/model/base.py
+++ b/transformers4rec/tf/model/base.py
@@ -384,7 +384,7 @@ class Head(tf.keras.layers.Layer):
         return outputs
 
     def compute_loss(
-        self, body_outputs, targets, training=False, call_body=False, **kwargs
+        self, body_outputs, targets, training=False, call_body=False, compute_metrics=True, **kwargs
     ) -> tf.Tensor:
         losses = []
 
@@ -394,7 +394,12 @@ class Head(tf.keras.layers.Layer):
         predictions = self(body_outputs, always_output_dict=True)
         for name, task in self.prediction_task_dict.items():
             loss = task.compute_loss(
-                predictions[name], targets, call_task=False, training=training, **kwargs
+                predictions[name],
+                targets,
+                call_task=False,
+                training=training,
+                compute_metrics=compute_metrics,
+                **kwargs,
             )
             losses.append(loss * self._task_weight_dict[name])
 

--- a/transformers4rec/tf/model/base.py
+++ b/transformers4rec/tf/model/base.py
@@ -27,6 +27,7 @@ from transformers import TFSequenceSummary
 from merlin_standard_lib import Schema, Tag
 
 from ..features.sequence import TabularFeaturesType
+from ..ranking_metric import process_metrics
 from ..utils.tf_utils import (
     LossMixin,
     MetricsMixin,
@@ -492,18 +493,6 @@ class BaseModel(tf.keras.Model, LossMixin, abc.ABC):
         metrics["total_loss"] = total_loss
 
         return metrics
-
-
-def process_metrics(metrics, prefix=""):
-    metrics_proc = {}
-    for metric in metrics:
-        results = metric.result()
-        if tf.shape(results)[0] > 1:
-            names = [f"{prefix}{metric.name}{ks}" for ks in metric.top_ks]
-            metrics_proc.update(dict(zip(names, results)))
-        else:
-            metrics_proc[metric.name] = results
-    return metrics_proc
 
 
 class Model(BaseModel):

--- a/transformers4rec/tf/model/base.py
+++ b/transformers4rec/tf/model/base.py
@@ -495,6 +495,7 @@ class BaseModel(tf.keras.Model, LossMixin, abc.ABC):
         return metrics
 
 
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class Model(BaseModel):
     def __init__(
         self, *head: Head, head_weights: Optional[List[float]] = None, name=None, **kwargs

--- a/transformers4rec/tf/model/prediction_task.py
+++ b/transformers4rec/tf/model/prediction_task.py
@@ -297,6 +297,7 @@ class NextItemPredictionTask(PredictionTask):
         return results
 
 
+@tf.keras.utils.register_keras_serializable(package="merlin_models")
 class _NextItemPredictionTask(tf.keras.layers.Layer):
     """Predict the interacted item-id probabilities.
     - During inference, the task consists of predicting the next item.
@@ -323,8 +324,9 @@ class _NextItemPredictionTask(tf.keras.layers.Layer):
         weight_tying: bool = False,
         item_embedding_table: Optional[tf.Variable] = None,
         softmax_temperature: float = 0,
+        **kwargs,
     ):
-        super().__init__()
+        super().__init__(**kwargs)
         self.target_dim = target_dim
         self.weight_tying = weight_tying
         self.item_embedding_table = item_embedding_table

--- a/transformers4rec/tf/model/prediction_task.py
+++ b/transformers4rec/tf/model/prediction_task.py
@@ -196,7 +196,7 @@ class NextItemPredictionTask(PredictionTask):
             labels = self.embeddings.item_seq
 
         # remove vectors of padded items
-        trg_flat = tf.reshape(labels, -1)
+        trg_flat = tf.reshape(labels, (-1,))
         non_pad_mask = trg_flat != self.padding_idx
         x = self.remove_pad_3d(x, non_pad_mask)
 
@@ -208,7 +208,7 @@ class NextItemPredictionTask(PredictionTask):
         # inp_tensor: (n_batch x seqlen x emb_dim)
         inp_tensor = tf.reshape(inp_tensor, (-1, inp_tensor.shape[-1]))
         inp_tensor_fl = tf.boolean_mask(
-            inp_tensor, tf.broadcast_to(tf.expand_dims(non_pad_mask, 1), inp_tensor.shape)
+            inp_tensor, tf.broadcast_to(tf.expand_dims(non_pad_mask, 1), tf.shape(inp_tensor))
         )
         out_tensor = tf.reshape(inp_tensor_fl, (-1, inp_tensor.shape[1]))
         return out_tensor
@@ -231,7 +231,7 @@ class NextItemPredictionTask(PredictionTask):
         if self.masking:
             targets = self.masking.masked_targets
             # flatten labels and remove padding index
-            targets = tf.reshape(targets, -1)
+            targets = tf.reshape(targets, (-1,))
             non_pad_mask = targets != self.padding_idx
             targets = tf.boolean_mask(targets, non_pad_mask)
 

--- a/transformers4rec/tf/model/prediction_task.py
+++ b/transformers4rec/tf/model/prediction_task.py
@@ -125,7 +125,7 @@ class NextItemPredictionTask(PredictionTask):
         target_name: Optional[str] = None,
         task_name: Optional[str] = None,
         task_block: Optional[Layer] = None,
-        weight_tying: bool = False,
+        weight_tying: bool = True,
         target_dim: int = None,
         softmax_temperature: float = 1,
         **kwargs,
@@ -321,7 +321,7 @@ class _NextItemPredictionTask(tf.keras.layers.Layer):
     def __init__(
         self,
         target_dim: int,
-        weight_tying: bool = False,
+        weight_tying: bool = True,
         item_embedding_table: Optional[tf.Variable] = None,
         softmax_temperature: float = 0,
         **kwargs,
@@ -382,4 +382,4 @@ class _NextItemPredictionTask(tf.keras.layers.Layer):
         return predictions
 
     def _get_name(self) -> str:
-        return "NextItemPredictionTask"
+        return "_NextItemPredictionTask"

--- a/transformers4rec/tf/model/prediction_task.py
+++ b/transformers4rec/tf/model/prediction_task.py
@@ -6,6 +6,7 @@ from tensorflow.keras.layers import Layer
 
 from ..block.mlp import MLPBlock
 from ..ranking_metric import AvgPrecisionAt, NDCGAt, RecallAt
+from ..utils.tf_utils import maybe_deserialize_keras_objects, maybe_serialize_keras_objects
 from .base import PredictionTask
 
 
@@ -348,6 +349,20 @@ class _NextItemPredictionTask(tf.keras.layers.Layer):
                 bias_initializer="zeros",
                 name="logits",
             )
+
+    @classmethod
+    def from_config(cls, config):
+        config = maybe_deserialize_keras_objects(config, ["output_layer"])
+        return super().from_config(config)
+
+    def get_config(self):
+        config = super().get_config()
+        config = maybe_serialize_keras_objects(self, config, ["output_layer"])
+        config["target_dim"] = self.target_dim
+        config["weight_tying"] = self.weight_tying
+        config["softmax_temperature"] = self.softmax_temperature
+
+        return config
 
     def call(self, inputs: tf.Tensor, **kwargs):
         if self.weight_tying:

--- a/transformers4rec/tf/model/prediction_task.py
+++ b/transformers4rec/tf/model/prediction_task.py
@@ -107,7 +107,9 @@ class NextItemPredictionTask(PredictionTask):
         Value 1.0 reduces to regular softmax.
     """
 
-    DEFAULT_LOSS = tf.keras.losses.SparseCategoricalCrossentropy()
+    DEFAULT_LOSS = tf.keras.losses.SparseCategoricalCrossentropy(
+        from_logits=True,
+    )
     DEFAULT_METRICS = (
         # default metrics suppose labels are int encoded
         NDCGAt(top_ks=[10, 20], labels_onehot=True),

--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -201,7 +201,7 @@ class RecallAt(RankingMetric):
 
 @ranking_metrics_registry.register_with_multiple_names("avg_precision_at", "avg_precision", "map")
 class AvgPrecisionAt(RankingMetric):
-    def __init__(self, top_ks=[1], labels_onehot=False):
+    def __init__(self, top_ks=None, labels_onehot=False):
         super(AvgPrecisionAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
         max_k = tf.reduce_max(self.top_ks)
         self.precision_at = PrecisionAt(top_ks=1 + tf.range(max_k))
@@ -247,7 +247,7 @@ class AvgPrecisionAt(RankingMetric):
 
 @ranking_metrics_registry.register_with_multiple_names("dcg_at", "dcg")
 class DCGAt(RankingMetric):
-    def __init__(self, top_ks=[1], labels_onehot=False):
+    def __init__(self, top_ks=None, labels_onehot=False):
         super(DCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
 
     def _metric(
@@ -297,7 +297,7 @@ class DCGAt(RankingMetric):
 
 @ranking_metrics_registry.register_with_multiple_names("ndcg_at", "ndcg")
 class NDCGAt(RankingMetric):
-    def __init__(self, top_ks=[1], labels_onehot=False):
+    def __init__(self, top_ks=None, labels_onehot=False):
         super(NDCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
         self.dcg_at = DCGAt(top_ks)
 

--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -67,6 +67,7 @@ class RankingMetric(tf.keras.metrics.Metric):
         if not self.built:
             self.accumulator = tf.Variable(
                 tf.zeros(shape=[1, len(self.top_ks)]),
+                trainable=False,
                 shape=tf.TensorShape([None, tf.compat.v1.Dimension(len(self.top_ks))]),
             )
 

--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -24,7 +24,7 @@ from merlin_standard_lib import Registry
 
 from .utils import tf_utils
 
-ranking_metrics_registry = Registry.class_registry("tf.ranking_metrics")
+ranking_metrics_registry = Registry("tf.ranking_metrics")
 
 METRIC_PARAMETERS_DOCSTRING = """
     ks : tf.Tensor
@@ -297,7 +297,7 @@ class DCGAt(RankingMetric):
 
 @ranking_metrics_registry.register_with_multiple_names("ndcg_at", "ndcg")
 class NDCGAt(RankingMetric):
-    def __init__(self, top_ks=None, labels_onehot=False):
+    def __init__(self, top_ks=[1], labels_onehot=False):
         super(NDCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
         self.dcg_at = DCGAt(top_ks)
 

--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -201,9 +201,9 @@ class RecallAt(RankingMetric):
 
 @ranking_metrics_registry.register_with_multiple_names("avg_precision_at", "avg_precision", "map")
 class AvgPrecisionAt(RankingMetric):
-    def __init__(self, top_ks=None, labels_onehot=False):
+    def __init__(self, top_ks=[1], labels_onehot=False):
         super(AvgPrecisionAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
-        max_k = tf.reduce_max(top_ks)
+        max_k = tf.reduce_max(self.top_ks)
         self.precision_at = PrecisionAt(top_ks=1 + tf.range(max_k))
 
     def _metric(self, ks: tf.Tensor, scores: tf.Tensor, labels: tf.Tensor) -> tf.Tensor:
@@ -247,7 +247,7 @@ class AvgPrecisionAt(RankingMetric):
 
 @ranking_metrics_registry.register_with_multiple_names("dcg_at", "dcg")
 class DCGAt(RankingMetric):
-    def __init__(self, top_ks=None, labels_onehot=False):
+    def __init__(self, top_ks=[1], labels_onehot=False):
         super(DCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
 
     def _metric(

--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -347,3 +347,15 @@ def check_inputs(ks, scores, labels):
     scores.get_shape().assert_is_compatible_with(labels.get_shape())
 
     return (tf.cast(ks, tf.int32), tf.cast(scores, tf.float32), tf.cast(labels, tf.float32))
+
+
+def process_metrics(metrics, prefix=""):
+    metrics_proc = {}
+    for metric in metrics:
+        results = metric.result()
+        if getattr(metric, "top_ks", None):
+            for i, ks in enumerate(metric.top_ks):
+                metrics_proc.update({f"{prefix}{metric.name}{ks}": tf.gather(results, i)})
+        else:
+            metrics_proc[metric.name] = results
+    return metrics_proc

--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -37,6 +37,7 @@ METRIC_PARAMETERS_DOCSTRING = """
 """
 
 
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class RankingMetric(tf.keras.metrics.Metric):
     """
     Metric wrapper for computing ranking metrics@K for session-based task.
@@ -106,6 +107,7 @@ class RankingMetric(tf.keras.metrics.Metric):
 
 
 @ranking_metrics_registry.register_with_multiple_names("precision_at", "precision")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class PrecisionAt(RankingMetric):
     def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
         super(PrecisionAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
@@ -142,6 +144,7 @@ class PrecisionAt(RankingMetric):
 
 
 @ranking_metrics_registry.register_with_multiple_names("recall_at", "recall")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class RecallAt(RankingMetric):
     def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
         super(RecallAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
@@ -196,6 +199,7 @@ class RecallAt(RankingMetric):
 
 
 @ranking_metrics_registry.register_with_multiple_names("avg_precision_at", "avg_precision", "map")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class AvgPrecisionAt(RankingMetric):
     def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
         super(AvgPrecisionAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
@@ -242,6 +246,7 @@ class AvgPrecisionAt(RankingMetric):
 
 
 @ranking_metrics_registry.register_with_multiple_names("dcg_at", "dcg")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class DCGAt(RankingMetric):
     def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
         super(DCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
@@ -292,6 +297,7 @@ class DCGAt(RankingMetric):
 
 
 @ranking_metrics_registry.register_with_multiple_names("ndcg_at", "ndcg")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class NDCGAt(RankingMetric):
     def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
         super(NDCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)

--- a/transformers4rec/tf/utils/repr_utils.py
+++ b/transformers4rec/tf/utils/repr_utils.py
@@ -83,7 +83,7 @@ def _layer_repr(self, track_children=True):
             children = children + to_add
 
         for key, child in children:
-            if not child:
+            if child is not None:
                 continue
             mod_str = repr(child)
             mod_str = _addindent(mod_str, 2)

--- a/transformers4rec/tf/utils/tf_utils.py
+++ b/transformers4rec/tf/utils/tf_utils.py
@@ -116,6 +116,16 @@ def calculate_batch_size_from_input_shapes(input_shapes):
     return [i for i in input_shapes.values() if not isinstance(i, tuple)][0][0]
 
 
+def get_tf_main_layer(hf_model):
+    """
+    Extract serializable custom keras layer `TF*MainLayer` from the HF model
+    """
+    main_layer = [v for _, v in hf_model.__dict__.items() if isinstance(v, tf.keras.layers.Layer)][
+        0
+    ]
+    return main_layer
+
+
 def maybe_serialize_keras_objects(
     self,
     config,
@@ -123,7 +133,7 @@ def maybe_serialize_keras_objects(
 ):
     for key in maybe_serialize_keys:
         maybe_value = getattr(self, key, None)
-        if maybe_value:
+        if maybe_value is not None:
             if isinstance(maybe_value, dict):
                 config[key] = {
                     k: tf.keras.utils.serialize_keras_object(v) for k, v in maybe_value.items()

--- a/transformers4rec/tf/utils/tf_utils.py
+++ b/transformers4rec/tf/utils/tf_utils.py
@@ -174,7 +174,7 @@ def gather_torch_like(labels, indices, max_k):
     # gather_indices = []
     gather_indices = tf.TensorArray(tf.int32, size=tf.shape(indices)[0])
     for i in range(tf.shape(indices)[0]):
-        gather_indices.write(
+        gather_indices = gather_indices.write(
             i,
             tf.concat(
                 [i * tf.ones((max_k, 1), tf.int32), tf.expand_dims(indices[i, :], -1)], axis=1

--- a/transformers4rec/torch/block/transformer.py
+++ b/transformers4rec/torch/block/transformer.py
@@ -94,13 +94,13 @@ class TransformerBlock(BlockBase):
                 masking.__class__
                 not in getattr(
                     MappingTransformerMasking,
-                    self.transformer.config_class.__name__,
+                    self.transformer.config_class.__name__,  # type: ignore
                     [masking.__class__],
                 )
             ):
                 raise ValueError(
-                    f"{masking.__class__.__name__} is not supported by: "
-                    f"the {self.transformer.config_class.__name__} architecture"
+                    f"{masking.__class__.__name__} is not supported by: "  # type: ignore
+                    f"the {self.transformer.config_class.__name__} architecture"  # type: ignore
                 )
 
             required = list(masking.transformer_required_arguments().keys())


### PR DESCRIPTION
Fixes #283 #262 #258 #236

### Goals :soccer: and Implementation Details :construction:

TL;DR: This PR was initially created to fix the saving of TF model needed by Triton serving  and the definition of Tensorflow version of getting started notebook.  The issue had a larger scope than the saving method and I had to refactor the custom classes `MaskSequence`, `NextItemPredictionTask`, `RankingMetric` and `TransformerBlock`. The main changes are: 

- [x] Update HuggingFace dependency to 4.11* to support Albert and ELECTRA. (Note that ELECTRA model still need feature #263 for working correctly)

- [x] Re-factor the tf ops used to define the custom classes to make sure they are working in both modes: `eager` and `graph`. 

- [x] Define `get_config` / `from_config` methods to the custom classes for model saving and loading. 

- [x] Add a non trainable tf.Variable to `RankingMetric` classes as placeholder to store the updated states at each iteration. This is needed in `graph` mode as the metrics are part of the Keras class `NextItemPredictionTask`.

- [x] Improve the signature HF transformers `call` to fix the issue of shape mismatch when saving the model. This error is linked to non-used arguments being initialized with wrong tensors: The previous call method provided transformer_kwargs twice, e.g. `mask_perm` was set equal to `input_embed` instead of None).  

- [x] Extract from the HF model the serializable layer TF*MainLayer. In fact, all the HF models are defined with one custom Keras layer containing the architecture graph. (e.g. [tfXLNetModel](https://github.com/huggingface/transformers/blob/9e4ea2517504f144e74d9a356d58e9f2be32b3fa/src/transformers/models/xlnet/modeling_tf_xlnet.py#L1160))

- [x] Fix the loss function used by `NextItemPredictionTask`. We set `logits=true` in SparseCategoricalCrossentropy as the task already returns the logit scores. 

- [x] Expose compute_metrics flag of `compute_loss` methods to compute metrics during train / evaluation.  The method `process_metric` is added to flatten the list of scores returned by ranking metrics with respect to their threshold. 

- [x] Create a TensorFlow version of the getting started notebook, including model definition, training, evaluation, saving, and reloading.  

- [ ] Re-load the model for:  model serving, calling the method on a batch of data (`model()`), resume training (`model.fit()`), and compute evaluation scores on new data (`model.evaluate()`)  
  -  Using `.save()` and `tf.keras.models.load_model()` allow for saving the model's architecture and its weights. Applying the re-loaded model is working. However calling `fit()` and `evaluate()` methods raise an input signature error ```ValueError: Could not find matching function to call loaded from the SavedModel.```
  -  The second solution is to use weight saving and loading (`save_weights` / `load_weights`) but we need to construct the model before loading weight.  In this case, we can resume training without any error. 


### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

- Add tests to `test_model.py`: 
   - `test_simple_seq_classification`: Add a test of the sequence classification model and check if loss decreasing.
   - `test_next_item_fit`: Test, next item prediction task, using eager and graph modes.
   - `test_simple_model`: Test saving and loading of a simple classification model.
   - `test_save_load_item_prediction`: Test saving and loading of next item prediction task with a simple model using an `MLP` block.
   -  `test_save_load_transformer_model`: Test saving and loading of next item prediction task with supported HF transformers.
   - `test_resume_training`: Test resume training of next item prediction task using weight saving and loading

- Update `test_transformer.py` to include Albert config. 

- Add `test_score_different_from_zero` to `test_ranking_metrics.py` to check that computed metrics are different from 0.  


### Remaining tasks out of scope of this PR: 
- Fix scores of ranking metrics returned by the fit/evaluate methods in the getting-started notebook: The current scores are inconsistent for `mlm` (close to one).  In fact, the model is always returning the last non-padded item suggesting there is a leakage in the model definition (might be related to the masking schema computed by the `TabularSequenceFeatures` module). 

- For `clm`, reported RecallAt seems correct, while NDCGAt is returning the same score for all thresholds (the issue might be related to the nested usage of DCGAt metric)



