### PR TITLE
Hf update

### DIFF
--- a/docs/source/resources.md
+++ b/docs/source/resources.md
@@ -37,6 +37,7 @@ Tip: Registering HF Transformers config classes into Transformers4Rec is a good 
 
 |   Model     | CLM |  MLM  |  PLM  |  RTD  | Registered |
 | ----------- |--------|-------|-------|-------|-------|
+|    [AlBERT](https://huggingface.co/transformers/model_doc/albert.html#bertconfig) |   ❌   |  ✅    |   ❌   |  ✅  |   ✅   |
 |    [BERT](https://huggingface.co/transformers/model_doc/bert.html#bertconfig)     |   ❌   |  ✅    |   ❌   |  ✅  |   ✅   |
 |  [ConvBERT](https://huggingface.co/transformers/model_doc/convbert.html#convbertconfig)   |   ❌   |  ✅    |   ❌   |  ✅  |   ❌   |
 |   [DeBERTa](https://huggingface.co/transformers/model_doc/deberta.html#debertaconfig)   |   ❌   |  ✅    |   ❌   |  ✅  |   ❌   |
@@ -51,7 +52,7 @@ Tip: Registering HF Transformers config classes into Transformers4Rec is a good 
 |   [XLNet](https://huggingface.co/transformers/model_doc/xlnet.html#xlnetconfig)    |   ✅    | ✅     |   ✅   |  ✅    |   ✅   |
 
 
- **Note**: The following HF architectures will be supported in future release: `Reformer`, `Funnel Transformer`, `ELECTRA` and `ALBERT`.
+ **Note**: The following HF architectures will be supported in future release: `Reformer`, `Funnel Transformer`, `ELECTRA`
 
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 numpy>=1.17.0
-transformers==4.9.*
+transformers==4.11.*
 tqdm>=4.27
 betterproto<2.0.0
 pyarrow>=1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,4 +11,5 @@ sphinx_markdown_tables
 sphinx_rtd_theme
 recommonmark>=0.6
 tensorflow-metadata
+tensorflow-estimator==2.6.*
 tensorflow-ranking>=0.4

--- a/requirements/tensorflow.txt
+++ b/requirements/tensorflow.txt
@@ -1,1 +1,1 @@
-tensorflow==2.6.*
+tensorflow>=2.3

--- a/requirements/tensorflow.txt
+++ b/requirements/tensorflow.txt
@@ -1,1 +1,1 @@
-tensorflow>=2.3
+tensorflow==2.6.*

--- a/tests/tf/block/test_transformer.py
+++ b/tests/tf/block/test_transformer.py
@@ -24,6 +24,7 @@ config_classes = [
     tconf.XLNetConfig,
     tconf.LongformerConfig,
     tconf.GPT2Config,
+    tconf.AlbertConfig,
 ]
 
 # fixed parameters for tests

--- a/tests/torch/block/test_transformer.py
+++ b/tests/torch/block/test_transformer.py
@@ -29,6 +29,7 @@ config_classes = [
     tconf.BertConfig,
     tconf.RobertaConfig,
     tconf.TransfoXLConfig,
+    tconf.AlbertConfig,
 ]
 
 # fixed parameters for tests

--- a/tests/torch/model/test_model.py
+++ b/tests/torch/model/test_model.py
@@ -151,8 +151,8 @@ def test_multi_head_model_wrong_weights(torch_tabular_features, torch_yoochoose_
 
 config_classes = [
     tconf.XLNetConfig,
-    # TODO: Add Electra when HF fix is released
-    # tconf.ElectraConfig,
+    # TODO: Add support of Electra 
+    tconf.AlbertConfig,
     tconf.LongformerConfig,
     tconf.GPT2Config,
 ]

--- a/tests/torch/model/test_model.py
+++ b/tests/torch/model/test_model.py
@@ -151,7 +151,7 @@ def test_multi_head_model_wrong_weights(torch_tabular_features, torch_yoochoose_
 
 config_classes = [
     tconf.XLNetConfig,
-    # TODO: Add support of Electra 
+    # TODO: Add support of Electra
     tconf.AlbertConfig,
     tconf.LongformerConfig,
     tconf.GPT2Config,

--- a/transformers4rec/torch/block/transformer.py
+++ b/transformers4rec/torch/block/transformer.py
@@ -94,13 +94,13 @@ class TransformerBlock(BlockBase):
                 masking.__class__
                 not in getattr(
                     MappingTransformerMasking,
-                    self.transformer.config_class.__name__, # type: ignore
+                    self.transformer.config_class.__name__,  # type: ignore
                     [masking.__class__],
                 )
             ):
                 raise ValueError(
-                    f"{masking.__class__.__name__} is not supported by: " # type: ignore
-                    f"the {self.transformer.config_class.__name__} architecture"# type: ignore
+                    f"{masking.__class__.__name__} is not supported by: "  # type: ignore
+                    f"the {self.transformer.config_class.__name__} architecture"  # type: ignore
                 )
 
             required = list(masking.transformer_required_arguments().keys())

--- a/transformers4rec/torch/block/transformer.py
+++ b/transformers4rec/torch/block/transformer.py
@@ -94,13 +94,13 @@ class TransformerBlock(BlockBase):
                 masking.__class__
                 not in getattr(
                     MappingTransformerMasking,
-                    self.transformer.config_class.__name__,
+                    self.transformer.config_class.__name__, # type: ignore
                     [masking.__class__],
                 )
             ):
                 raise ValueError(
-                    f"{masking.__class__.__name__} is not supported by: "
-                    f"the {self.transformer.config_class.__name__} architecture"
+                    f"{masking.__class__.__name__} is not supported by: " # type: ignore
+                    f"the {self.transformer.config_class.__name__} architecture"# type: ignore
                 )
 
             required = list(masking.transformer_required_arguments().keys())


### PR DESCRIPTION
Fixes #262 #297 #124 

### Goals :soccer:

- This PR updates the version of the HF library to fix the error raised by Albert and Electra related to a missing seq_len argument.  

- It also fixes the tf-estimator version to 2.6.* as the latest version 2.7 from the 30th of October is not compatible with tf_ranking package. 

- Albert is added to the unit tests and to the table listing the supported architectures. 

- For the ELECTRA model, there is still an open task  #263  that needs to be resolved before integrating it. 


### Implementation Details :construction:
- Update the requirements of transformers to 4.11.*

### Testing Details :mag:
- Add AlbertConfig to torch and tf unit tests. 
