### PR TITLE
Refactor RankingMetric to fix serialization and graph-mode

### DIFF
--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -16,14 +16,16 @@
 
 # Adapted from source code: https://github.com/karlhigley/ranking-metrics-torch
 from abc import abstractmethod
+from typing import List
 
+import numpy as np
 import tensorflow as tf
 
 from merlin_standard_lib import Registry
 
 from .utils import tf_utils
 
-ranking_metrics_registry = Registry.class_registry("tf.ranking_metrics")
+ranking_metrics_registry = Registry("tf.ranking_metrics")
 
 METRIC_PARAMETERS_DOCSTRING = """
     ks : tf.Tensor
@@ -35,10 +37,10 @@ METRIC_PARAMETERS_DOCSTRING = """
 """
 
 
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class RankingMetric(tf.keras.metrics.Metric):
     """
     Metric wrapper for computing ranking metrics@K for session-based task.
-
     Parameters
     ----------
     top_ks : list, default [2, 5])
@@ -53,13 +55,33 @@ class RankingMetric(tf.keras.metrics.Metric):
         self.labels_onehot = labels_onehot
         # Store the mean vector of the batch metrics (for each cut-off at topk) in ListWrapper
         self.metric_mean = []
+        self.accumulator = tf.Variable(
+            tf.zeros(shape=[1, len(self.top_ks)]),
+            trainable=False,
+            shape=tf.TensorShape([None, tf.compat.v1.Dimension(len(self.top_ks))]),
+        )
+
+    def get_config(self):
+        config = {"top_ks": self.top_ks, "labels_onehot": self.labels_onehot}
+        base_config = super(RankingMetric, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def _build(self, shape):
+        bs = shape[0]
+        variable_shape = [bs, tf.compat.v1.Dimension(len(self.top_ks))]
+        self.accumulator.assign(tf.zeros(variable_shape))
 
     def update_state(self, y_true: tf.Tensor, y_pred: tf.Tensor, **kwargs):
         # Computing the metrics at different cut-offs
+        # init batch accumulator
+        self._build(shape=tf.shape(y_pred))
         if self.labels_onehot:
-            y_true = tf_utils.tranform_label_to_onehot(y_true, y_pred.shape[-1])
+            y_true = tf_utils.tranform_label_to_onehot(y_true, tf.shape(y_pred)[-1])
+
         metric = self._metric(
-            tf.convert_to_tensor(self.top_ks), tf.reshape(y_pred, [-1, y_pred.shape[-1]]), y_true
+            ks=tf.convert_to_tensor(self.top_ks),
+            scores=tf.reshape(y_pred, [-1, tf.shape(y_pred)[-1]]),
+            labels=y_true,
         )
         self.metric_mean.append(metric)
 
@@ -71,11 +93,10 @@ class RankingMetric(tf.keras.metrics.Metric):
         self.metric_mean = []
 
     @abstractmethod
-    def _metric(self, ks: tf.Tensor, preds: tf.Tensor, target: tf.Tensor) -> tf.Tensor:
+    def _metric(self, ks: tf.Tensor, scores: tf.Tensor, labels: tf.Tensor) -> tf.Tensor:
         """
         Compute ranking metric over predictions and one-hot targets for different cut-offs.
         This method should be overridden by subclasses.
-
         Parameters
         ----------
         {METRIC_PARAMETERS_DOCSTRING}
@@ -84,14 +105,14 @@ class RankingMetric(tf.keras.metrics.Metric):
 
 
 @ranking_metrics_registry.register_with_multiple_names("precision_at", "precision")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class PrecisionAt(RankingMetric):
-    def __init__(self, top_ks=None, labels_onehot=False):
-        super(PrecisionAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
+    def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
+        super(PrecisionAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
 
-    def _metric(self, ks: tf.Tensor, scores: tf.Tensor, labels: tf.Tensor) -> tf.Tensor:
+    def _metric(self, ks: List[int], scores: tf.Tensor, labels: tf.Tensor) -> tf.Tensor:
         """
         Compute precision@K for each provided cutoff in ks
-
         Parameters
         ----------
         {METRIC_PARAMETERS_DOCSTRING}
@@ -99,23 +120,35 @@ class PrecisionAt(RankingMetric):
 
         ks, scores, labels = check_inputs(ks, scores, labels)
         _, _, topk_labels = tf_utils.extract_topk(ks, scores, labels)
-        precisions = tf_utils.create_output_placeholder(scores, ks)
+        bs = tf.shape(scores)[0]
 
-        for index, k in enumerate(ks):
-            precisions[:, index].assign(tf.reduce_sum(topk_labels[:, : int(k)], axis=1) / float(k))
+        for index in range(int(tf.shape(ks)[0])):
+            k = ks[index]
+            rows_ids = tf.range(bs, dtype=tf.int64)
+            indices = tf.concat(
+                [
+                    tf.expand_dims(rows_ids, 1),
+                    tf.cast(index, tf.int64) * tf.ones([bs, 1], dtype=tf.int64),
+                ],
+                axis=1,
+            )
 
-        return precisions
+            self.accumulator.scatter_nd_update(
+                indices=indices, updates=tf.reduce_sum(topk_labels[:, : int(k)], axis=1) / float(k)
+            )
+
+        return self.accumulator
 
 
 @ranking_metrics_registry.register_with_multiple_names("recall_at", "recall")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class RecallAt(RankingMetric):
-    def __init__(self, top_ks=None, labels_onehot=False):
-        super(RecallAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
+    def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
+        super(RecallAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
 
-    def _metric(self, ks: tf.Tensor, scores: tf.Tensor, labels: tf.Tensor) -> tf.Tensor:
+    def _metric(self, ks: List[int], scores: tf.Tensor, labels: tf.Tensor) -> tf.Tensor:
         """
         Compute recall@K for each provided cutoff in ks
-
         Parameters
         ----------
         {METRIC_PARAMETERS_DOCSTRING}
@@ -123,15 +156,15 @@ class RecallAt(RankingMetric):
 
         ks, scores, labels = check_inputs(ks, scores, labels)
         _, _, topk_labels = tf_utils.extract_topk(ks, scores, labels)
-        recalls = tf_utils.create_output_placeholder(scores, ks)
 
         # Compute recalls at K
         num_relevant = tf.reduce_sum(labels, axis=-1)
         rel_indices = tf.where(num_relevant != 0)
         rel_count = tf.gather_nd(num_relevant, rel_indices)
 
-        if rel_indices.shape[0] > 0:
-            for index, k in enumerate(ks):
+        if tf.shape(rel_indices)[0] > 0:
+            for index in range(int(tf.shape(ks)[0])):
+                k = ks[index]
                 rel_labels = tf.cast(
                     tf.gather_nd(topk_labels, rel_indices)[:, : int(k)], tf.float32
                 )
@@ -147,71 +180,85 @@ class RecallAt(RankingMetric):
                 update_indices = tf.concat(
                     [
                         rel_indices,
-                        tf.expand_dims(index * tf.ones(rel_indices.shape[0], tf.int64), -1),
+                        tf.expand_dims(
+                            tf.cast(index, tf.int64) * tf.ones(tf.shape(rel_indices)[0], tf.int64),
+                            -1,
+                        ),
                     ],
                     axis=1,
                 )
-                recalls = tf.tensor_scatter_nd_update(
-                    recalls, indices=update_indices, updates=tf.reshape(batch_recall_k, -1)
+                self.accumulator.scatter_nd_update(
+                    indices=update_indices, updates=tf.reshape(batch_recall_k, (-1,))
                 )
 
-        return recalls
+        return self.accumulator
 
 
 @ranking_metrics_registry.register_with_multiple_names("avg_precision_at", "avg_precision", "map")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class AvgPrecisionAt(RankingMetric):
-    def __init__(self, top_ks=None, labels_onehot=False):
-        super(AvgPrecisionAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
-        self.precision_at = PrecisionAt(top_ks)._metric
+    def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
+        super(AvgPrecisionAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
+        max_k = tf.reduce_max(self.top_ks)
+        self.precision_at = PrecisionAt(top_ks=1 + np.array((range(max_k))))
 
-    def _metric(self, ks: tf.Tensor, scores: tf.Tensor, labels: tf.Tensor) -> tf.Tensor:
+    def _metric(self, ks: List[int], scores: tf.Tensor, labels: tf.Tensor) -> tf.Tensor:
         """
         Compute average precision @K for provided cutoff in ks
-
         Parameters
         ----------
         {METRIC_PARAMETERS_DOCSTRING}
         """
         ks, scores, labels = check_inputs(ks, scores, labels)
         topk_scores, _, topk_labels = tf_utils.extract_topk(ks, scores, labels)
-        avg_precisions = tf_utils.create_output_placeholder(scores, ks)
 
         num_relevant = tf.reduce_sum(labels, axis=-1)
         max_k = tf.reduce_max(ks)
 
-        precisions = self.precision_at(1 + tf.range(max_k), topk_scores, topk_labels)
+        bs = tf.shape(scores)[0]
+        self.precision_at._build(shape=tf.shape(scores))
+        precisions = self.precision_at._metric(1 + tf.range(max_k), topk_scores, topk_labels)
         rel_precisions = precisions * topk_labels
 
-        for index, k in enumerate(ks):
+        for index in range(int(tf.shape(ks)[0])):
+            k = ks[index]
             tf_total_prec = tf.reduce_sum(rel_precisions[:, :k], axis=1)
             clip_value = tf.clip_by_value(
                 num_relevant, clip_value_min=1, clip_value_max=tf.cast(k, tf.float32)
             )
-            avg_precisions[:, index].assign(tf_total_prec / clip_value)
+
+            rows_ids = tf.range(bs, dtype=tf.int64)
+            indices = tf.concat(
+                [
+                    tf.expand_dims(rows_ids, 1),
+                    tf.cast(index, tf.int64) * tf.ones([bs, 1], dtype=tf.int64),
+                ],
+                axis=1,
+            )
+            self.accumulator.scatter_nd_update(indices=indices, updates=tf_total_prec / clip_value)
             # Ensuring type is double, because it can be float if --fp16
-        return avg_precisions
+        return self.accumulator
 
 
 @ranking_metrics_registry.register_with_multiple_names("dcg_at", "dcg")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class DCGAt(RankingMetric):
-    def __init__(self, top_ks=None, labels_onehot=False):
-        super(DCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
+    def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
+        super(DCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
 
     def _metric(
-        self, ks: tf.Tensor, scores: tf.Tensor, labels: tf.Tensor, log_base: int = 2
+        self, ks: List[int], scores: tf.Tensor, labels: tf.Tensor, log_base: int = 2
     ) -> tf.Tensor:
 
         """
         Compute discounted cumulative gain @K for each provided cutoff in ks
         (ignoring ties)
-
         Parameters
         ----------
         {METRIC_PARAMETERS_DOCSTRING}
         """
         ks, scores, labels = check_inputs(ks, scores, labels)
         _, _, topk_labels = tf_utils.extract_topk(ks, scores, labels)
-        dcgs = tf_utils.create_output_placeholder(scores, ks)
 
         # Compute discounts
         max_k = tf.reduce_max(ks)
@@ -219,32 +266,44 @@ class DCGAt(RankingMetric):
         discount_log_base = tf.math.log(tf.convert_to_tensor([log_base], dtype=tf.float32))
 
         discounts = 1 / (tf.math.log(discount_positions + 2) / discount_log_base)
-
+        bs = tf.shape(scores)[0]
         # Compute DCGs at K
-        for index, k in enumerate(ks):
+        for index in range(len(self.top_ks)):
+            k = ks[index]
             m = topk_labels[:, :k] * tf.repeat(
-                tf.expand_dims(discounts[:k], 0), topk_labels.shape[0], axis=0
+                tf.expand_dims(discounts[:k], 0), tf.shape(topk_labels)[0], axis=0
             )
-            dcgs[:, index].assign(tf.cast(tf.reduce_sum(m, axis=1), tf.float32))
+            rows_ids = tf.range(bs, dtype=tf.int64)
+            indices = tf.concat(
+                [
+                    tf.expand_dims(rows_ids, 1),
+                    tf.cast(index, tf.int64) * tf.ones([bs, 1], dtype=tf.int64),
+                ],
+                axis=1,
+            )
+
+            self.accumulator.scatter_nd_update(
+                indices=indices, updates=tf.cast(tf.reduce_sum(m, axis=1), tf.float32)
+            )
             # Ensuring type is double, because it can be float if --fp16
 
-        return dcgs
+        return self.accumulator
 
 
 @ranking_metrics_registry.register_with_multiple_names("ndcg_at", "ndcg")
+@tf.keras.utils.register_keras_serializable(package="transformers4rec")
 class NDCGAt(RankingMetric):
-    def __init__(self, top_ks=None, labels_onehot=False):
-        super(NDCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
-        self.dcg_at = DCGAt(top_ks)._metric
+    def __init__(self, top_ks=None, labels_onehot=False, **kwargs):
+        super(NDCGAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot, **kwargs)
+        self.dcg_at = DCGAt(top_ks)
 
     def _metric(
-        self, ks: tf.Tensor, scores: tf.Tensor, labels: tf.Tensor, log_base: int = 2
+        self, ks: List[int], scores: tf.Tensor, labels: tf.Tensor, log_base: int = 2
     ) -> tf.Tensor:
 
         """
         Compute normalized discounted cumulative gain @K for each provided cutoffs in ks
         (ignoring ties)
-
         Parameters
         ----------
         {METRIC_PARAMETERS_DOCSTRING}
@@ -253,17 +312,25 @@ class NDCGAt(RankingMetric):
         topk_scores, _, topk_labels = tf_utils.extract_topk(ks, scores, labels)
 
         # Compute discounted cumulative gains
-        gains = self.dcg_at(ks, topk_scores, topk_labels, log_base=log_base)
-        normalizing_gains = self.dcg_at(ks, topk_labels, topk_labels, log_base=log_base)
+        self.dcg_at._build(shape=tf.shape(scores))
+        gains = self.dcg_at._metric(
+            ks=ks, labels=topk_labels, scores=topk_scores, log_base=log_base
+        )
+        self.accumulator.assign(gains)
+        # Re-init states of dcg_at
+        self.dcg_at._build(shape=tf.shape(scores))
+        normalizing_gains = self.dcg_at._metric(
+            ks=ks, labels=topk_labels, scores=topk_labels, log_base=log_base
+        )
 
         # Prevent divisions by zero
         relevant_pos = tf.where(normalizing_gains != 0)
-        tf.where(normalizing_gains == 0, 0, gains)
+        tf.where(normalizing_gains == 0, 0.0, gains)
 
         updates = tf.gather_nd(gains, relevant_pos) / tf.gather_nd(normalizing_gains, relevant_pos)
-        gains = tf.tensor_scatter_nd_update(gains, relevant_pos, updates)
+        self.accumulator.scatter_nd_update(relevant_pos, updates)
 
-        return gains
+        return self.accumulator
 
 
 def check_inputs(ks, scores, labels):
@@ -276,7 +343,18 @@ def check_inputs(ks, scores, labels):
     if len(labels.shape) != 2:
         raise ValueError("labels must be a 2-dimensional tensor")
 
-    if scores.shape != labels.shape:
-        raise ValueError("scores and labels must be the same shape")
+    scores.get_shape().assert_is_compatible_with(labels.get_shape())
 
     return (tf.cast(ks, tf.int32), tf.cast(scores, tf.float32), tf.cast(labels, tf.float32))
+
+
+def process_metrics(metrics, prefix=""):
+    metrics_proc = {}
+    for metric in metrics:
+        results = metric.result()
+        if getattr(metric, "top_ks", None):
+            for i, ks in enumerate(metric.top_ks):
+                metrics_proc.update({f"{prefix}{metric.name}{ks}": tf.gather(results, i)})
+        else:
+            metrics_proc[metric.name] = results
+    return metrics_proc


### PR DESCRIPTION
Fixes #283 

### Goals :soccer:

- [x] Re-factor the tf ops used to define the RankingMetric classes to make sure they are working in both modes: `eager` and `graph`. 

- [x] Define `get_config` / `from_config` methods to the custom classes for serialization.

- [x] Add a non trainable tf.Variable to `RankingMetric` classes as placeholder to store the updated states at each iteration. This is needed in `graph` mode as the metrics are part of the Keras class `NextItemPredictionTask`.

- [x]   The method `process_metric` is added to flatten the list of scores returned by ranking metrics with respect to their threshold

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
- Add `test_score_different_from_zero`  to check that computed metrics are different from 0.  
- Add `test_serialization_ranking_metric` to check the serialization of RankingMetric classes.