### PR TITLE
fix error related to compatibility between keras and tf

### DIFF
--- a/requirements/tensorflow.txt
+++ b/requirements/tensorflow.txt
@@ -1,1 +1,2 @@
 tensorflow>=2.3
+keras==2.6.*


### PR DESCRIPTION
- Pin the version of keras to 2.6.* to fix the error related to the latest release of keras 2.7. 

- You can find more detail about the issue [here](https://github.com/keras-team/keras/issues/15579)