### PR TITLE
Fix a bug in GPU evaluation with PyArrow dataloader

### DIFF
--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -288,6 +288,7 @@ class Trainer(BaseTrainer):
         like returning labels that are not exactly one input feature
         model
         """
+        inputs = self._prepare_inputs(inputs)
         with torch.no_grad():
             if self.use_amp:
                 with autocast():


### PR DESCRIPTION
Fixes #284.

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Currently, setting the training argument as `data_loader_engine="pyarrow"` and `no_cuda=False` leads to an error during the evaluation stage.
To my understanding, this is because the input batch is not moved to the GPU by Trainer.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Following the HF [Trainer](https://github.com/huggingface/transformers/blob/280a811ecb7d2f63e7e83e0b05fb411b63e30ddc/src/transformers/trainer.py#L2452) implementation, I added a single line of code.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

I've tested this on my single-GPU machine, and it didn't produce any further errors.
Since this change is made based on the HF's implementation, I believe it should work in other settings as well.

Please check it out. Thanks!
