### PR TITLE
Getting-started notebook with CLM task 

### DIFF
--- a/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
+++ b/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "882fa1cb",
+   "execution_count": null,
+   "id": "470172f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7c70368",
+   "id": "405f926d",
    "metadata": {},
    "source": [
     "# Session-based Recommendation with XLNET"
@@ -33,28 +33,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0496eb3",
+   "id": "732a8a58",
    "metadata": {},
    "source": [
-    "In this notebook we introduce the [Transformers4Rec](https://github.com/NVIDIA-Merlin/Transformers4Rec) library for sequential and session-based recommendation. This notebook uses the PyTorch API, but a TensorFlow API is also available. Transformers4Rec integrates with the popular [HuggingFace’s Transformers](https://github.com/huggingface/transformers) and make it possible to experiment with cutting-edge implementation of the latest NLP Transformer architectures.  \n",
+    "In this notebook we introduce the [Transformers4Rec](https://github.com/NVIDIA-Merlin/Transformers4Rec) library for sequential and session-based recommendation. This notebook uses the Tensorflow API built with TensorFlow 2.x, but a PyTorch API is also available (see [example](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/examples/getting-started-session-based/02-session-based-XLNet-with-PyT.ipynb)). Transformers4Rec integrates with the popular [HuggingFace’s Transformers](https://github.com/huggingface/transformers) and make it possible to experiment with cutting-edge implementation of the latest NLP Transformer architectures.  \n",
     "\n",
     "We demonstrate how to build a session-based recommendation model with the [XLNET](https://arxiv.org/abs/1906.08237) Transformer architecture. The XLNet architecture was designed to leverage the best of both auto-regressive language modeling and auto-encoding with its Permutation Language Modeling training method. In this example we will use XLNET with causal language modeling (CLM) training method. "
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "31a3cf40",
+   "id": "cdd721c4",
    "metadata": {},
    "source": [
     "In the previous notebook we went through our ETL pipeline with NVTabular library, and created sequential features to be used in training a session-based recommendation model. In this notebook we will learn:\n",
     "\n",
-    "- Accelerating data loading of parquet files with multiple features on PyTorch using NVTabular library\n",
+    "- Accelerating data loading of parquet files with multiple features on Tensorflow using NVTabular library\n",
     "- Training and evaluating a Transformer-based (XLNET-CLM) session-based recommendation model with multiple features"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "518a0cc8",
+   "id": "5e0c69aa",
    "metadata": {},
    "source": [
     "## Build a DL model with Transformers4Rec library  "
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63a0ae39",
+   "id": "1956dd6a",
    "metadata": {},
    "source": [
     "Transformers4Rec supports multiple input features and provides configurable building blocks that can be easily combined for custom architectures:\n",
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd2a330f",
+   "id": "ae50b8aa",
    "metadata": {},
    "source": [
     "Figure 1 illustrates Transformers4Rec meta-architecture and how each module/block interacts with each other."
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bafd4c2",
+   "id": "13c5be59",
    "metadata": {},
    "source": [
     "![tf4rec_meta](images/tf4rec_meta2.png)"
@@ -95,25 +95,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b8e6bca",
+   "id": "ad7d2b9d",
    "metadata": {},
    "source": [
-    "### Imports required libraries"
+    "## Import required libraries"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "2ae49de1",
+   "id": "1c64b1ad",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-11-18 16:30:19.596179: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "2021-11-24 17:16:37.072740: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2021-11-18 16:30:21.358586: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1510] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 8080 MB memory:  -> device: 0, name: Tesla V100-SXM2-16GB-N, pci bus id: 0000:0b:00.0, compute capability: 7.0\n"
+      "2021-11-24 17:16:38.461237: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1510] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 16249 MB memory:  -> device: 0, name: Quadro GV100, pci bus id: 0000:2d:00.0, compute capability: 7.0\n"
      ]
     }
    ],
@@ -124,7 +124,7 @@
     "from nvtabular.loader.tensorflow import KerasSequenceLoader\n",
     "\n",
     "from transformers4rec import tf as tr\n",
-    "from transformers4rec.tf.ranking_metric import NDCGAt, AvgPrecisionAt, RecallAt\n",
+    "from transformers4rec.tf.ranking_metric import NDCGAt, RecallAt\n",
     "\n",
     "import logging\n",
     "logging.disable(logging.WARNING) # disable INFO and DEBUG logging everywhere"
@@ -132,24 +132,36 @@
   },
   {
    "cell_type": "markdown",
-   "id": "477cc905",
+   "id": "a50f5729",
    "metadata": {},
    "source": [
     "Transformers4Rec library relies on a schema object to automatically build all necessary layers to represent, normalize and aggregate input features. As you can see below, `schema.pb` is a protobuf file that contains metadata including statistics about features such as cardinality, min and max values and also tags features based on their characteristics and dtypes (e.g., categorical, continuous, list, integer)."
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f88751cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# avoid numba warnings\n",
+    "from numba import config\n",
+    "config.CUDA_LOW_OCCUPANCY_WARNINGS = 0"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "e101b71c",
+   "id": "e7b2ad1c",
    "metadata": {},
    "source": [
-    "### Manually set the schema "
+    "## Set the schema "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "52a20432",
+   "execution_count": 4,
+   "id": "b6a1691f",
    "metadata": {},
    "outputs": [
     {
@@ -255,8 +267,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "871d515b",
+   "execution_count": 5,
+   "id": "ed415697",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,15 +281,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26b9302e",
+   "id": "95c2c8b3",
    "metadata": {},
    "source": [
-    "### Define the sequential input module"
+    "## Define the sequential input module"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "20be9964",
+   "id": "c5837aaf",
    "metadata": {},
    "source": [
     "Below we define our `input` block using the `TabularSequenceFeatures` [class](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/features/sequence.py#L121). The `from_schema()` method processes the schema and creates the necessary layers to represent features and aggregate them. It keeps only features tagged as `categorical` and `continuous` and supports data aggregation methods like `concat` and `elementwise-sum` techniques. It also support data augmentation techniques like stochastic swap noise. It outputs an interaction representation after combining all features and also the input mask according to the training task (more on this later).\n"
@@ -285,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c912a9a",
+   "id": "7cd9b1ca",
    "metadata": {},
    "source": [
     "The `max_sequence_length` argument defines the maximum sequence length of our sequential input, and if `continuous_projection` argument is set, all numerical features are concatenated and projected by an MLP block so that continuous features are represented by a vector of size defined by user, which is `64` in this example."
@@ -293,8 +305,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "da17ea3f",
+   "execution_count": 6,
+   "id": "801c0468",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee072b1c",
+   "id": "b798dc59",
    "metadata": {},
    "source": [
     "The output of the `TabularSequenceFeatures` module is the sequence of interactions embeddings vectors defined in the following steps:\n",
@@ -322,15 +334,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e347a744",
+   "id": "f43da993",
    "metadata": {},
    "source": [
-    "### Define the Transformer Block"
+    "## Define the Transformer Block"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3239040f",
+   "id": "62cbe1c8",
    "metadata": {},
    "source": [
     "In the next cell, the whole model is build with a few lines of code. \n",
@@ -342,8 +354,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "e24e0e6d",
+   "execution_count": 7,
+   "id": "658b6eec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,44 +382,46 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cafc8f0a",
+   "id": "1cc532da",
    "metadata": {},
    "source": [
-    "### Train the model "
+    "## Set DataLoader"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a7a073cf",
+   "id": "cf6940dc",
    "metadata": {},
    "source": [
-    "We use the NVTabular `KerasSequenceLoader` Dataloader for optimized loading of multiple features from input parquet files. You can learn more about this data loader [here](https://nvidia-merlin.github.io/NVTabular/main/training/tensorflow.html)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1711d7a6",
-   "metadata": {},
-   "source": [
-    "### **Set DataLoader**"
+    "We use the NVTabular `KerasSequenceLoader` Dataloader for optimized loading of multiple features from input parquet files. In our experiments, we see a speed-up by 9x of the same training workflow with NVTabular dataloader. NVTabular dataloader’s features are:\n",
+    "\n",
+    "- removing bottleneck of item-by-item dataloading\n",
+    "- enabling larger than memory dataset by streaming from disk\n",
+    "- reading data directly into GPU memory and remove CPU-GPU communication\n",
+    "- preparing batch asynchronously in GPU to avoid CPU-GPU communication\n",
+    "- supporting commonly used .parquet format\n",
+    "- easy integration into existing TensorFlow pipelines by using similar API - works with tf.keras models\n",
+    "\n",
+    "You can learn more about this data loader [here](https://nvidia-merlin.github.io/NVTabular/main/training/tensorflow.html) and [here](https://medium.com/nvidia-merlin/training-deep-learning-based-recommender-systems-9x-faster-with-tensorflow-cc5a2572ea49)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "e468a433",
+   "execution_count": 8,
+   "id": "36663685",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Define categorical and continuous columns\n",
     "x_cat_names, x_cont_names = ['category-list_trim', 'item_id-list_trim'], ['timestamp/age_days-list_trim', 'timestamp/weekday/sin-list_trim']\n",
     "\n",
-    "# dictionary representing max sequence length for column\n",
+    "# dictionary representing max sequence length for each column\n",
     "sparse_features_max = {\n",
     "    fname: 20\n",
     "    for fname in x_cat_names + x_cont_names\n",
     "}\n",
     "\n",
-    "def get_dataloader(paths_or_dataset, batch_size=64):\n",
+    "def get_dataloader(paths_or_dataset, batch_size=128):\n",
     "    dataloader = KerasSequenceLoader(\n",
     "        paths_or_dataset,\n",
     "        batch_size=batch_size,\n",
@@ -423,30 +437,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "395deb08",
-   "metadata": {},
-   "source": [
-    "## Set training params"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "c375eeeb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tensorflow as tf\n",
-    "lr_schedule = tf.keras.optimizers.schedules.CosineDecay(\n",
-    "    initial_learning_rate=0.0005,\n",
-    "    decay_steps=1.5)\n",
-    "optimizer = tf.keras.optimizers.Adam(learning_rate=lr_schedule)\n",
-    "model.compile(optimizer=\"adam\", run_eagerly=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4b902bc8",
+   "id": "f87dbe56",
    "metadata": {},
    "source": [
     "## Daily Fine-Tuning: Training over a time window"
@@ -454,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b804f1b",
+   "id": "e77219b0",
    "metadata": {},
    "source": [
     "Here we do daily fine-tuning meaning that we use the first day to train and second day to evaluate, then we use the second day data to train the model by resuming from the first step, and evaluate on the third day, so on so forth."
@@ -462,16 +453,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ff9b209",
+   "id": "f7a406ac",
    "metadata": {},
    "source": [
-    "- Define the output folder of the processed parquet files"
+    "Define the output folder of the processed parquet files"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "811f6121",
+   "id": "08f002de",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,9 +470,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bdc59389",
+   "metadata": {},
+   "source": [
+    "### Train the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b8b64906",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "model.compile(optimizer=\"adam\", run_eagerly=True)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "a4a0572a",
+   "id": "24447db3",
    "metadata": {},
    "outputs": [
     {
@@ -498,8 +509,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-11-18 16:30:29.316737: I tensorflow/stream_executor/cuda/cuda_dnn.cc:369] Loaded cuDNN version 8204\n",
-      "2021-11-18 16:30:29.540981: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:185] None of the MLIR Optimization Passes are enabled (registered 2)\n"
+      "2021-11-24 17:16:47.136720: I tensorflow/stream_executor/cuda/cuda_dnn.cc:369] Loaded cuDNN version 8204\n",
+      "2021-11-24 17:16:47.282196: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:185] None of the MLIR Optimization Passes are enabled (registered 2)\n"
      ]
     },
     {
@@ -507,62 +518,62 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/5\n",
-      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.0030 - train_ndcg@40: 0.0046 - train_recall@20: 0.0078 - train_recall@40: 0.0160 - loss: 10.7693 - regularization_loss: 0.0000e+00 - total_loss: 10.7693\n",
+      "7/7 [==============================] - 22s 3s/step - train_ndcg@20: 0.0026 - train_ndcg@40: 0.0028 - train_recall@20: 0.0050 - train_recall@40: 0.0061 - loss: 10.8527 - regularization_loss: 0.0000e+00 - total_loss: 10.8527\n",
       "Epoch 2/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.0685 - train_ndcg@40: 0.0802 - train_recall@20: 0.1480 - train_recall@40: 0.2050 - loss: 9.1048 - regularization_loss: 0.0000e+00 - total_loss: 9.1048\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.0313 - train_ndcg@40: 0.0357 - train_recall@20: 0.0672 - train_recall@40: 0.0886 - loss: 9.8833 - regularization_loss: 0.0000e+00 - total_loss: 9.8833\n",
       "Epoch 3/5\n",
-      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1363 - train_ndcg@40: 0.1695 - train_recall@20: 0.3396 - train_recall@40: 0.5022 - loss: 7.4349 - regularization_loss: 0.0000e+00 - total_loss: 7.4349\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.0906 - train_ndcg@40: 0.1005 - train_recall@20: 0.2174 - train_recall@40: 0.2661 - loss: 8.9810 - regularization_loss: 0.0000e+00 - total_loss: 8.9810\n",
       "Epoch 4/5\n",
-      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1542 - train_ndcg@40: 0.1966 - train_recall@20: 0.4040 - train_recall@40: 0.6110 - loss: 5.9372 - regularization_loss: 0.0000e+00 - total_loss: 5.9372\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.1235 - train_ndcg@40: 0.1497 - train_recall@20: 0.3307 - train_recall@40: 0.4586 - loss: 8.1265 - regularization_loss: 0.0000e+00 - total_loss: 8.1265\n",
       "Epoch 5/5\n",
-      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1639 - train_ndcg@40: 0.2163 - train_recall@20: 0.4244 - train_recall@40: 0.6806 - loss: 5.1375 - regularization_loss: 0.0000e+00 - total_loss: 5.1375\n",
-      "2/2 [==============================] - 1s 296ms/step - eval_ndcg@20: 0.1827 - eval_ndcg@40: 0.2315 - eval_recall@20: 0.4877 - eval_recall@40: 0.7256 - loss: 4.7567 - regularization_loss: 0.0000e+00 - total_loss: 4.7567\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.1292 - train_ndcg@40: 0.1730 - train_recall@20: 0.3561 - train_recall@40: 0.5703 - loss: 7.2556 - regularization_loss: 0.0000e+00 - total_loss: 7.2556\n",
+      "1/1 [==============================] - 3s 3s/step - eval_ndcg@20: 0.1371 - eval_ndcg@40: 0.1823 - eval_recall@20: 0.3801 - eval_recall@40: 0.5980 - loss: 6.8134 - regularization_loss: 0.0000e+00 - total_loss: 6.8134\n",
       "********************\n",
       "Eval results for day 2 are:\t\n",
       "\n",
       "********************\n",
       "\n",
-      " eval_ndcg@20 = 0.1788734793663025\n",
-      " eval_ndcg@40 = 0.2327456772327423\n",
-      " eval_recall@20 = 0.4736842215061188\n",
-      " eval_recall@40 = 0.7368420958518982\n",
-      " loss = 4.716386795043945\n",
+      " eval_ndcg@20 = 0.13714689016342163\n",
+      " eval_ndcg@40 = 0.18226708471775055\n",
+      " eval_recall@20 = 0.38009950518608093\n",
+      " eval_recall@40 = 0.5980099439620972\n",
+      " loss = 6.81339168548584\n",
       " regularization_loss = 0\n",
-      " total_loss = 4.716386795043945\n",
+      " total_loss = 6.81339168548584\n",
       "********************\n",
       "Launch training for day 2 are:\n",
       "********************\n",
       "\n",
       "Epoch 1/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1685 - train_ndcg@40: 0.2231 - train_recall@20: 0.4700 - train_recall@40: 0.7368 - loss: 4.8112 - regularization_loss: 0.0000e+00 - total_loss: 4.8112\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.1350 - train_ndcg@40: 0.1832 - train_recall@20: 0.3581 - train_recall@40: 0.5898 - loss: 6.4791 - regularization_loss: 0.0000e+00 - total_loss: 6.4791\n",
       "Epoch 2/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1680 - train_ndcg@40: 0.2213 - train_recall@20: 0.4611 - train_recall@40: 0.7229 - loss: 4.7283 - regularization_loss: 0.0000e+00 - total_loss: 4.7283\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.1472 - train_ndcg@40: 0.1974 - train_recall@20: 0.3793 - train_recall@40: 0.6229 - loss: 5.7670 - regularization_loss: 0.0000e+00 - total_loss: 5.7670\n",
       "Epoch 3/5\n",
-      "15/15 [==============================] - 31s 2s/step - train_ndcg@20: 0.1720 - train_ndcg@40: 0.2265 - train_recall@20: 0.4640 - train_recall@40: 0.7306 - loss: 4.6544 - regularization_loss: 0.0000e+00 - total_loss: 4.6544\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.1674 - train_ndcg@40: 0.2100 - train_recall@20: 0.4410 - train_recall@40: 0.6505 - loss: 5.2392 - regularization_loss: 0.0000e+00 - total_loss: 5.2392\n",
       "Epoch 4/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1723 - train_ndcg@40: 0.2295 - train_recall@20: 0.4582 - train_recall@40: 0.7385 - loss: 4.6317 - regularization_loss: 0.0000e+00 - total_loss: 4.6317\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.1761 - train_ndcg@40: 0.2243 - train_recall@20: 0.4710 - train_recall@40: 0.7071 - loss: 4.8951 - regularization_loss: 0.0000e+00 - total_loss: 4.8951\n",
       "Epoch 5/5\n",
-      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1673 - train_ndcg@40: 0.2254 - train_recall@20: 0.4533 - train_recall@40: 0.7367 - loss: 4.6163 - regularization_loss: 0.0000e+00 - total_loss: 4.6163\n",
-      "2/2 [==============================] - 1s 254ms/step - eval_ndcg@20: 0.1643 - eval_ndcg@40: 0.2186 - eval_recall@20: 0.4822 - eval_recall@40: 0.7501 - loss: 4.4777 - regularization_loss: 0.0000e+00 - total_loss: 4.4777\n",
+      "7/7 [==============================] - 21s 3s/step - train_ndcg@20: 0.1864 - train_ndcg@40: 0.2375 - train_recall@20: 0.4934 - train_recall@40: 0.7415 - loss: 4.6883 - regularization_loss: 0.0000e+00 - total_loss: 4.6883\n",
+      "1/1 [==============================] - 3s 3s/step - eval_ndcg@20: 0.1768 - eval_ndcg@40: 0.2286 - eval_recall@20: 0.4763 - eval_recall@40: 0.7302 - loss: 4.6789 - regularization_loss: 0.0000e+00 - total_loss: 4.6789\n",
       "********************\n",
       "Eval results for day 3 are:\t\n",
       "\n",
       "********************\n",
       "\n",
-      " eval_ndcg@20 = 0.17018109560012817\n",
-      " eval_ndcg@40 = 0.21519054472446442\n",
-      " eval_recall@20 = 0.4888888895511627\n",
-      " eval_recall@40 = 0.7111111283302307\n",
-      " loss = 4.539609909057617\n",
+      " eval_ndcg@20 = 0.17680498957633972\n",
+      " eval_ndcg@40 = 0.2286442071199417\n",
+      " eval_recall@20 = 0.47628459334373474\n",
+      " eval_recall@40 = 0.7302371263504028\n",
+      " loss = 4.678927421569824\n",
       " regularization_loss = 0\n",
-      " total_loss = 4.539609909057617\n"
+      " total_loss = 4.678927421569824\n"
      ]
     }
    ],
    "source": [
     "start_time_window_index = 1\n",
     "final_time_window_index = 3\n",
-    "#Iterating over days of one week\n",
+    "# Iterating over days of one week\n",
     "for time_index in range(start_time_window_index, final_time_window_index):\n",
     "    # Set data \n",
     "    time_index_train = time_index\n",
@@ -589,42 +600,42 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a59e7b9",
+   "id": "ffb08c26",
    "metadata": {},
    "source": [
-    "### Saves the model"
+    "## Save the model"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "e60a0e15",
+   "id": "90691db7",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-11-18 16:36:05.689344: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+      "2021-11-24 17:20:32.337934: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
      ]
     }
    ],
    "source": [
-    "model.save('tmp/tensorflow')"
+    "model.save('./tmp/tensorflow')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9da34948",
+   "id": "6bf23206",
    "metadata": {},
    "source": [
-    "### Reloads the model"
+    "## Reload the model"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "44f4436c",
+   "id": "6df10beb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +645,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "cef7197b",
+   "id": "25599e1c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,26 +655,26 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "93a0f974",
+   "id": "b486c5c9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<tf.Tensor: shape=(64, 50006), dtype=float32, numpy=\n",
-       "array([[-14.886165 , -15.133767 ,  -3.1503913, ..., -15.143302 ,\n",
-       "        -14.165563 , -13.621665 ],\n",
-       "       [-14.905037 , -15.140341 ,  -3.1269689, ..., -15.163202 ,\n",
-       "        -14.157326 , -13.655285 ],\n",
-       "       [-14.849622 , -15.11325  ,  -3.2750463, ..., -15.082913 ,\n",
-       "        -14.251033 , -13.546626 ],\n",
+       "<tf.Tensor: shape=(118, 50006), dtype=float32, numpy=\n",
+       "array([[-13.77997  , -11.321821 ,  -3.4781942, ..., -12.7864895,\n",
+       "        -13.239983 , -13.766869 ],\n",
+       "       [-13.768703 , -11.319653 ,  -3.4630215, ..., -12.772872 ,\n",
+       "        -13.257902 , -13.800142 ],\n",
+       "       [-13.795613 , -11.329163 ,  -3.4603472, ..., -12.7655   ,\n",
+       "        -13.299693 , -13.799895 ],\n",
        "       ...,\n",
-       "       [-14.884882 , -15.14102  ,  -3.3538773, ..., -15.109003 ,\n",
-       "        -14.1946745, -13.515995 ],\n",
-       "       [-14.798379 , -15.08512  ,  -3.2425992, ..., -15.098843 ,\n",
-       "        -14.163866 , -13.492168 ],\n",
-       "       [-14.90872  , -15.083946 ,  -3.319263 , ..., -15.099293 ,\n",
-       "        -14.140776 , -13.505323 ]], dtype=float32)>"
+       "       [-13.7550335, -11.327356 ,  -3.4488232, ..., -12.773474 ,\n",
+       "        -13.267937 , -13.7868   ],\n",
+       "       [-13.756104 , -11.325677 ,  -3.4566376, ..., -12.775398 ,\n",
+       "        -13.245429 , -13.793298 ],\n",
+       "       [-13.7463665, -11.3194275,  -3.4377723, ..., -12.755983 ,\n",
+       "        -13.272619 , -13.808911 ]], dtype=float32)>"
       ]
      },
      "execution_count": 15,
@@ -672,16 +683,17 @@
     }
    ],
    "source": [
+    "# Generate predictions (logits) from reloaded model with a batch\n",
     "model(batch[0])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "feb1bc78",
+   "id": "a20ca21b",
    "metadata": {},
    "source": [
     "That's it!  \n",
-    "You have just trained your session-based recommendation model using Transformers4Rec."
+    "You have just trained your session-based recommendation model using Transformers4Rec Tensorflow API."
    ]
   }
  ],

--- a/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
+++ b/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
@@ -1,0 +1,723 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84a18ed2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 NVIDIA Corporation. All Rights Reserved.\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License.\n",
+    "# =============================================================================="
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c6e0b09",
+   "metadata": {},
+   "source": [
+    "# Session-based Recommendation with XLNET"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1011c249",
+   "metadata": {},
+   "source": [
+    "In this notebook we introduce the [Transformers4Rec](https://github.com/NVIDIA-Merlin/Transformers4Rec) library for sequential and session-based recommendation. This notebook uses the PyTorch API, but a TensorFlow API is also available. Transformers4Rec integrates with the popular [HuggingFace’s Transformers](https://github.com/huggingface/transformers) and make it possible to experiment with cutting-edge implementation of the latest NLP Transformer architectures.  \n",
+    "\n",
+    "We demonstrate how to build a session-based recommendation model with the [XLNET](https://arxiv.org/abs/1906.08237) Transformer architecture. The XLNet architecture was designed to leverage the best of both auto-regressive language modeling and auto-encoding with its Permutation Language Modeling training method. In this example we will use XLNET with masked language modeling (MLM) training method, which showed very promising results in the experiments conducted in our [ACM RecSys'21 paper](https://github.com/NVIDIA-Merlin/publications/blob/main/2021_acm_recsys_transformers4rec/recsys21_transformers4rec_paper.pdf)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caadfcd0",
+   "metadata": {},
+   "source": [
+    "In the previous notebook we went through our ETL pipeline with NVTabular library, and created sequential features to be used in training a session-based recommendation model. In this notebook we will learn:\n",
+    "\n",
+    "- Accelerating data loading of parquet files with multiple features on PyTorch using NVTabular library\n",
+    "- Training and evaluating a Transformer-based (XLNET-MLM) session-based recommendation model with multiple features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b7eee2b",
+   "metadata": {},
+   "source": [
+    "## Build a DL model with Transformers4Rec library  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3afdd23",
+   "metadata": {},
+   "source": [
+    "Transformers4Rec supports multiple input features and provides configurable building blocks that can be easily combined for custom architectures:\n",
+    "\n",
+    "- [TabularSequenceFeatures](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.torch.TabularSequenceFeatures) class that reads from schema and creates an input block. This input module combines different types of features (continuous, categorical & text) to a sequence.\n",
+    "-  [MaskSequence](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/masking.py) to define masking schema and prepare the masked inputs and labels for the selected LM task.\n",
+    "-  [TransformerBlock](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.torch.TransformerBlock) class that supports HuggingFace Transformers for session-based and sequential-based recommendation models.\n",
+    "-  [SequentialBlock](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.torch.SequentialBlock) creates the body by mimicking [tf.keras.Sequential](https://www.tensorflow.org/api_docs/python/tf/keras/Sequential) class. It is designed to define our model as a sequence of layers.\n",
+    "-  [Head](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.tf.Head) where we define the prediction task of the model.\n",
+    "-  [NextItemPredictionTask](https://nvidia-merlin.github.io/Transformers4Rec/main/api/transformers4rec.tf.html#transformers4rec.tf.NextItemPredictionTask) is the class to support next item prediction task.\n",
+    "\n",
+    "You can check the [full documentation](https://nvidia-merlin.github.io/Transformers4Rec/main/index.html) of Transformers4Rec if needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b04b39",
+   "metadata": {},
+   "source": [
+    "Figure 1 illustrates Transformers4Rec meta-architecture and how each module/block interacts with each other."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfef2d12",
+   "metadata": {},
+   "source": [
+    "![tf4rec_meta](images/tf4rec_meta2.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da37e6d3",
+   "metadata": {},
+   "source": [
+    "### Imports required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "481426d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-11-17 19:15:27.849759: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2021-11-17 19:15:29.625089: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1510] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 8080 MB memory:  -> device: 0, name: Tesla V100-SXM2-16GB-N, pci bus id: 0000:0b:00.0, compute capability: 7.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import glob\n",
+    "\n",
+    "from nvtabular.loader.tensorflow import KerasSequenceLoader\n",
+    "\n",
+    "from transformers4rec import tf as tr\n",
+    "from transformers4rec.tf.ranking_metric import NDCGAt, AvgPrecisionAt, RecallAt\n",
+    "\n",
+    "import logging\n",
+    "logging.disable(logging.WARNING) # disable INFO and DEBUG logging everywhere"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33be17c5",
+   "metadata": {},
+   "source": [
+    "Transformers4Rec library relies on a schema object to automatically build all necessary layers to represent, normalize and aggregate input features. As you can see below, `schema.pb` is a protobuf file that contains metadata including statistics about features such as cardinality, min and max values and also tags features based on their characteristics and dtypes (e.g., categorical, continuous, list, integer)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22d9599e",
+   "metadata": {},
+   "source": [
+    "### Manually set the schema "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9e4a6ef8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "feature {\n",
+      "  name: \"session_id\"\n",
+      "  type: INT\n",
+      "  int_domain {\n",
+      "    name: \"session_id\"\n",
+      "    min: 1\n",
+      "    max: 100001\n",
+      "    is_categorical: false\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"groupby_col\"\n",
+      "  }\n",
+      "}\n",
+      "feature {\n",
+      "  name: \"category-list_trim\"\n",
+      "  value_count {\n",
+      "    min: 2\n",
+      "    max: 20\n",
+      "  }\n",
+      "  type: INT\n",
+      "  int_domain {\n",
+      "    name: \"category-list_trim\"\n",
+      "    min: 1\n",
+      "    max: 400\n",
+      "    is_categorical: true\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"list\"\n",
+      "    tag: \"categorical\"\n",
+      "    tag: \"item\"\n",
+      "  }\n",
+      "}\n",
+      "feature {\n",
+      "  name: \"item_id-list_trim\"\n",
+      "  value_count {\n",
+      "    min: 2\n",
+      "    max: 20\n",
+      "  }\n",
+      "  type: INT\n",
+      "  int_domain {\n",
+      "    name: \"item_id/list\"\n",
+      "    min: 1\n",
+      "    max: 50005\n",
+      "    is_categorical: true\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"item_id\"\n",
+      "    tag: \"list\"\n",
+      "    tag: \"categorical\"\n",
+      "    tag: \"item\"\n",
+      "  }\n",
+      "}\n",
+      "feature {\n",
+      "  name: \"timestamp/age_days-list_trim\"\n",
+      "  value_count {\n",
+      "    min: 2\n",
+      "    max: 20\n",
+      "  }\n",
+      "  type: FLOAT\n",
+      "  float_domain {\n",
+      "    name: \"timestamp/age_days-list_trim\"\n",
+      "    min: 0.0000003\n",
+      "    max: 0.9999999\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"continuous\"\n",
+      "    tag: \"list\"\n",
+      "  }\n",
+      "}\n",
+      "feature {\n",
+      "  name: \"timestamp/weekday/sin-list_trim\"\n",
+      "  value_count {\n",
+      "    min: 2\n",
+      "    max: 20\n",
+      "  }\n",
+      "  type: FLOAT\n",
+      "  float_domain {\n",
+      "    name: \"timestamp/weekday-sin_trim\"\n",
+      "    min: 0.0000003\n",
+      "    max: 0.9999999\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"continuous\"\n",
+      "    tag: \"time\"\n",
+      "    tag: \"list\"\n",
+      "  }\n",
+      "}"
+     ]
+    }
+   ],
+   "source": [
+    "from merlin_standard_lib import Schema\n",
+    "SCHEMA_PATH = \"schema.pb\"\n",
+    "schema = Schema().from_proto_text(SCHEMA_PATH)\n",
+    "!cat $SCHEMA_PATH"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "054bb34e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can select a subset of features for training\n",
+    "schema = schema.select_by_name(['item_id-list_trim', \n",
+    "                                'category-list_trim', \n",
+    "                                'timestamp/weekday/sin-list_trim',\n",
+    "                                'timestamp/age_days-list_trim'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "991791f2",
+   "metadata": {},
+   "source": [
+    "### Define the sequential input module"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b4229e9",
+   "metadata": {},
+   "source": [
+    "Below we define our `input` block using the `TabularSequenceFeatures` [class](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/features/sequence.py#L121). The `from_schema()` method processes the schema and creates the necessary layers to represent features and aggregate them. It keeps only features tagged as `categorical` and `continuous` and supports data aggregation methods like `concat` and `elementwise-sum` techniques. It also support data augmentation techniques like stochastic swap noise. It outputs an interaction representation after combining all features and also the input mask according to the training task (more on this later).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f1772c",
+   "metadata": {},
+   "source": [
+    "The `max_sequence_length` argument defines the maximum sequence length of our sequential input, and if `continuous_projection` argument is set, all numerical features are concatenated and projected by an MLP block so that continuous features are represented by a vector of size defined by user, which is `64` in this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4f9d7c18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs = tr.TabularSequenceFeatures.from_schema(\n",
+    "        schema,\n",
+    "        max_sequence_length=20,\n",
+    "        continuous_projection=64,\n",
+    "        d_output=64,\n",
+    "        masking=\"clm\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49f6380e",
+   "metadata": {},
+   "source": [
+    "The output of the `TabularSequenceFeatures` module is the sequence of interactions embeddings vectors defined in the following steps:\n",
+    "- 1. Create sequence inputs: If the schema contains non sequential features, expand each feature to a sequence by repeating the value as many as the `max_sequence_length` value.  \n",
+    "- 2. Get a representation vector of categorical features: Project each sequential categorical feature using the related embedding table. The resulting tensor is of shape (bs, max_sequence_length, embed_dim).\n",
+    "- 3. Project scalar values if `continuous_projection` is set : Apply an MLP layer with hidden size equal to `continuous_projection` vector size value. The resulting tensor is of shape (batch_size, max_sequence_length, continuous_projection).\n",
+    "- 4. Aggregate the list of features vectors to represent each interaction in the sequence with one vector: For example, `concat` will concat all vectors based on the last dimension `-1` and the resulting tensor will be of shape (batch_size, max_sequence_length, D) where D is the sum over all embedding dimensions and the value of continuous_projection. \n",
+    "- 5. If masking schema is set (needed only for the NextItemPredictionTask training), the masked labels are derived from the sequence of raw item-ids and the sequence of interactions embeddings are processed to mask information about the masked positions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1b31049",
+   "metadata": {},
+   "source": [
+    "### Define the Transformer Block"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd4c6a8e",
+   "metadata": {},
+   "source": [
+    "In the next cell, the whole model is build with a few lines of code. \n",
+    "Here is a brief explanation of the main classes:  \n",
+    "- [XLNetConfig](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/config/transformer.py#L261) - We have injected in the HF transformers config classes like `XLNetConfig` the `build()` method, that provides default configuration to Transformer architectures for session-based recommendation. Here we use it to instantiate and configure an XLNET architecture.  \n",
+    "- [TransformerBlock](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/block/transformer.py#L42) class integrates with HF Transformers, which are made available as a sequence processing module for session-based and sequential-based recommendation models.  \n",
+    "- [NextItemPredictionTask](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/405e3142f1274b1b0d642f4834ac437f2549cd33/transformers4rec/tf/model/prediction_task.py#82) supports the next-item prediction task. We also support other predictions [tasks](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/model/prediction_task.py), like classification and regression for the whole sequence. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "da77bb18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define XLNetConfig class and set default parameters for HF XLNet config  \n",
+    "transformer_config = tr.XLNetConfig.build(\n",
+    "    d_model=64, n_head=4, n_layer=2, total_seq_length=20\n",
+    ")\n",
+    "# Define the model block including: inputs, masking, projection and transformer block.\n",
+    "body = tr.SequentialBlock(\n",
+    "    [inputs, tr.TransformerBlock(transformer_config, masking=inputs.masking)]\n",
+    ")\n",
+    "\n",
+    "# Defines the evaluation top-N metrics and the cut-offs\n",
+    "metrics = [\n",
+    "    NDCGAt(top_ks=[20, 40], labels_onehot=True),  \n",
+    "    RecallAt(top_ks=[20, 40], labels_onehot=True)\n",
+    "]\n",
+    "\n",
+    "# link task to body and generate the end-to-end keras model\n",
+    "task = tr.NextItemPredictionTask(weight_tying=True, metrics=metrics)\n",
+    "\n",
+    "model = task.to_model(body=body)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c937391",
+   "metadata": {},
+   "source": [
+    "### Train the model "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09390aaa",
+   "metadata": {},
+   "source": [
+    "We use the NVTabular `KerasSequenceLoader` Dataloader for optimized loading of multiple features from input parquet files. You can learn more about this data loader [here](https://nvidia-merlin.github.io/NVTabular/main/training/tensorflow.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44919132",
+   "metadata": {},
+   "source": [
+    "### **Set DataLoader**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b64fcad1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_cat_names, x_cont_names = ['category-list_trim', 'item_id-list_trim'], ['timestamp/age_days-list_trim', 'timestamp/weekday/sin-list_trim']\n",
+    "\n",
+    "# dictionary representing max sequence length for column\n",
+    "sparse_features_max = {\n",
+    "    fname: 20\n",
+    "    for fname in x_cat_names + x_cont_names\n",
+    "}\n",
+    "\n",
+    "def get_dataloader(paths_or_dataset, batch_size=64):\n",
+    "    dataloader = KerasSequenceLoader(\n",
+    "        paths_or_dataset,\n",
+    "        batch_size=batch_size,\n",
+    "        label_names=None,\n",
+    "        cat_names=x_cat_names,\n",
+    "        cont_names=x_cont_names,\n",
+    "        sparse_names=list(sparse_features_max.keys()),\n",
+    "        sparse_max=sparse_features_max,\n",
+    "        sparse_as_dense=True,\n",
+    "    )\n",
+    "    return dataloader.map(lambda X, y: (X, []))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30948503",
+   "metadata": {},
+   "source": [
+    "## Set training params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ad3b7571",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "lr_schedule = tf.keras.optimizers.schedules.CosineDecay(\n",
+    "    initial_learning_rate=0.0005,\n",
+    "    decay_steps=1.5)\n",
+    "optimizer = tf.keras.optimizers.Adam(learning_rate=lr_schedule)\n",
+    "model.compile(optimizer=\"adam\", run_eagerly=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c13ef04",
+   "metadata": {},
+   "source": [
+    "## Daily Fine-Tuning: Training over a time window"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "126035e4",
+   "metadata": {},
+   "source": [
+    "Here we do daily fine-tuning meaning that we use the first day to train and second day to evaluate, then we use the second day data to train the model by resuming from the first step, and evaluate on the third day, so on so forth."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1d75967",
+   "metadata": {},
+   "source": [
+    "- Define the output folder of the processed parquet files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1d65282f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OUTPUT_DIR = os.environ.get(\"OUTPUT_DIR\", \"/workspace/data/sessions_by_day\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "40761b6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import logging\n",
+    "logging.set_verbosity_error()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "141c961f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "********************\n",
+      "Launch training for day 1 are:\n",
+      "********************\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-11-17 19:15:37.980096: I tensorflow/stream_executor/cuda/cuda_dnn.cc:369] Loaded cuDNN version 8204\n",
+      "2021-11-17 19:15:38.196940: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:185] None of the MLIR Optimization Passes are enabled (registered 2)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/5\n",
+      "15/15 [==============================] - 34s 2s/step - train_ndcg@20: 0.0032 - train_ndcg@40: 0.0044 - train_recall@20: 0.0099 - train_recall@40: 0.0155 - loss: 10.7448 - regularization_loss: 0.0000e+00 - total_loss: 10.7448\n",
+      "Epoch 2/5\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.0675 - train_ndcg@40: 0.0794 - train_recall@20: 0.1586 - train_recall@40: 0.2161 - loss: 9.0805 - regularization_loss: 0.0000e+00 - total_loss: 9.0805\n",
+      "Epoch 3/5\n",
+      "15/15 [==============================] - 34s 2s/step - train_ndcg@20: 0.1308 - train_ndcg@40: 0.1669 - train_recall@20: 0.3277 - train_recall@40: 0.5055 - loss: 7.3849 - regularization_loss: 0.0000e+00 - total_loss: 7.3849\n",
+      "Epoch 4/5\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1479 - train_ndcg@40: 0.1922 - train_recall@20: 0.3941 - train_recall@40: 0.6113 - loss: 5.9321 - regularization_loss: 0.0000e+00 - total_loss: 5.9321\n",
+      "Epoch 5/5\n",
+      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1697 - train_ndcg@40: 0.2185 - train_recall@20: 0.4360 - train_recall@40: 0.6740 - loss: 5.0944 - regularization_loss: 0.0000e+00 - total_loss: 5.0944\n",
+      "2/2 [==============================] - 1s 290ms/step - eval_ndcg@20: 0.1736 - eval_ndcg@40: 0.2243 - eval_recall@20: 0.5006 - eval_recall@40: 0.7477 - loss: 4.7323 - regularization_loss: 0.0000e+00 - total_loss: 4.7323\n",
+      "********************\n",
+      "Eval results for day 2 are:\t\n",
+      "\n",
+      "********************\n",
+      "\n",
+      " eval_ndcg@20 = 0.18473437428474426\n",
+      " eval_ndcg@40 = 0.2354496419429779\n",
+      " eval_recall@20 = 0.5087719559669495\n",
+      " eval_recall@40 = 0.7543859481811523\n",
+      " loss = 4.700231075286865\n",
+      " regularization_loss = 0\n",
+      " total_loss = 4.700231075286865\n",
+      "********************\n",
+      "Launch training for day 2 are:\n",
+      "********************\n",
+      "\n",
+      "Epoch 1/5\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1660 - train_ndcg@40: 0.2242 - train_recall@20: 0.4339 - train_recall@40: 0.7177 - loss: 4.8249 - regularization_loss: 0.0000e+00 - total_loss: 4.8249\n",
+      "Epoch 2/5\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1672 - train_ndcg@40: 0.2227 - train_recall@20: 0.4604 - train_recall@40: 0.7327 - loss: 4.7189 - regularization_loss: 0.0000e+00 - total_loss: 4.7189\n",
+      "Epoch 3/5\n",
+      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1736 - train_ndcg@40: 0.2282 - train_recall@20: 0.4633 - train_recall@40: 0.7310 - loss: 4.6492 - regularization_loss: 0.0000e+00 - total_loss: 4.6492\n",
+      "Epoch 4/5\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1692 - train_ndcg@40: 0.2260 - train_recall@20: 0.4542 - train_recall@40: 0.7322 - loss: 4.6401 - regularization_loss: 0.0000e+00 - total_loss: 4.6401\n",
+      "Epoch 5/5\n",
+      "15/15 [==============================] - 34s 2s/step - train_ndcg@20: 0.1770 - train_ndcg@40: 0.2323 - train_recall@20: 0.4653 - train_recall@40: 0.7359 - loss: 4.6038 - regularization_loss: 0.0000e+00 - total_loss: 4.6038\n",
+      "2/2 [==============================] - 1s 249ms/step - eval_ndcg@20: 0.1778 - eval_ndcg@40: 0.2368 - eval_recall@20: 0.4613 - eval_recall@40: 0.7501 - loss: 4.4416 - regularization_loss: 0.0000e+00 - total_loss: 4.4416\n",
+      "********************\n",
+      "Eval results for day 3 are:\t\n",
+      "\n",
+      "********************\n",
+      "\n",
+      " eval_ndcg@20 = 0.1962771713733673\n",
+      " eval_ndcg@40 = 0.24134907126426697\n",
+      " eval_recall@20 = 0.4888888895511627\n",
+      " eval_recall@40 = 0.7111111283302307\n",
+      " loss = 4.488396644592285\n",
+      " regularization_loss = 0\n",
+      " total_loss = 4.488396644592285\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_time_window_index = 1\n",
+    "final_time_window_index = 3\n",
+    "#Iterating over days of one week\n",
+    "for time_index in range(start_time_window_index, final_time_window_index):\n",
+    "    # Set data \n",
+    "    time_index_train = time_index\n",
+    "    time_index_eval = time_index + 1\n",
+    "    train_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_train}/train.parquet\"))\n",
+    "    eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
+    "    \n",
+    "    # Train on day related to time_index \n",
+    "    print('*'*20)\n",
+    "    print(\"Launch training for day %s are:\" %time_index)\n",
+    "    print('*'*20 + '\\n')\n",
+    "    train_loader = get_dataloader(train_paths) \n",
+    "    losses = model.fit(train_loader, epochs=5)\n",
+    "    model.reset_metrics()\n",
+    "    # Evaluate on the following day\n",
+    "    eval_loader = get_dataloader(eval_paths) \n",
+    "    eval_metrics = model.evaluate(eval_loader, return_dict=True)\n",
+    "    print('*'*20)\n",
+    "    print(\"Eval results for day %s are:\\t\" %time_index_eval)\n",
+    "    print('\\n' + '*'*20 + '\\n')\n",
+    "    for key in sorted(eval_metrics.keys()):\n",
+    "        print(\" %s = %s\" % (key, str(eval_metrics[key]))) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dae1bbe1",
+   "metadata": {},
+   "source": [
+    "### Saves the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a9129885",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-11-17 19:21:22.282683: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.save('tmp/tensorflow')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea49aa5d",
+   "metadata": {},
+   "source": [
+    "### Reloads the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "7f5f69dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = tf.keras.models.load_model('./tmp/tensorflow')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "3cca4090",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch = next(iter(eval_loader))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e471504d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(64, 50006), dtype=float32, numpy=\n",
+       "array([[-14.483589 , -15.827689 ,  -3.2657387, ..., -15.472676 ,\n",
+       "        -14.786966 , -15.284707 ],\n",
+       "       [-14.517188 , -15.770086 ,  -3.3817382, ..., -15.530424 ,\n",
+       "        -14.766118 , -15.170356 ],\n",
+       "       [-14.461672 , -15.592571 ,  -3.2989364, ..., -15.317642 ,\n",
+       "        -14.794083 , -15.200134 ],\n",
+       "       ...,\n",
+       "       [-14.512834 , -15.774984 ,  -3.2765167, ..., -15.475362 ,\n",
+       "        -14.711787 , -15.197722 ],\n",
+       "       [-14.5886345, -15.740798 ,  -3.3435194, ..., -15.510273 ,\n",
+       "        -14.731354 , -15.161112 ],\n",
+       "       [-14.604326 , -15.766655 ,  -3.3291552, ..., -15.422941 ,\n",
+       "        -14.72044  , -15.21335  ]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model(batch[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1359e70b",
+   "metadata": {},
+   "source": [
+    "That's it!  \n",
+    "You have just trained your session-based recommendation model using Transformers4Rec."
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "7b543a88d374ac88bf8df97911b380f671b13649694a5b49eb21e60fd27eb479"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
+++ b/examples/getting-started-session-based/03-session-based-XLNet-with-TF.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "84a18ed2",
+   "execution_count": 1,
+   "id": "882fa1cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c6e0b09",
+   "id": "d7c70368",
    "metadata": {},
    "source": [
     "# Session-based Recommendation with XLNET"
@@ -33,28 +33,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1011c249",
+   "id": "e0496eb3",
    "metadata": {},
    "source": [
     "In this notebook we introduce the [Transformers4Rec](https://github.com/NVIDIA-Merlin/Transformers4Rec) library for sequential and session-based recommendation. This notebook uses the PyTorch API, but a TensorFlow API is also available. Transformers4Rec integrates with the popular [HuggingFace’s Transformers](https://github.com/huggingface/transformers) and make it possible to experiment with cutting-edge implementation of the latest NLP Transformer architectures.  \n",
     "\n",
-    "We demonstrate how to build a session-based recommendation model with the [XLNET](https://arxiv.org/abs/1906.08237) Transformer architecture. The XLNet architecture was designed to leverage the best of both auto-regressive language modeling and auto-encoding with its Permutation Language Modeling training method. In this example we will use XLNET with masked language modeling (MLM) training method, which showed very promising results in the experiments conducted in our [ACM RecSys'21 paper](https://github.com/NVIDIA-Merlin/publications/blob/main/2021_acm_recsys_transformers4rec/recsys21_transformers4rec_paper.pdf)."
+    "We demonstrate how to build a session-based recommendation model with the [XLNET](https://arxiv.org/abs/1906.08237) Transformer architecture. The XLNet architecture was designed to leverage the best of both auto-regressive language modeling and auto-encoding with its Permutation Language Modeling training method. In this example we will use XLNET with causal language modeling (CLM) training method. "
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "caadfcd0",
+   "id": "31a3cf40",
    "metadata": {},
    "source": [
     "In the previous notebook we went through our ETL pipeline with NVTabular library, and created sequential features to be used in training a session-based recommendation model. In this notebook we will learn:\n",
     "\n",
     "- Accelerating data loading of parquet files with multiple features on PyTorch using NVTabular library\n",
-    "- Training and evaluating a Transformer-based (XLNET-MLM) session-based recommendation model with multiple features"
+    "- Training and evaluating a Transformer-based (XLNET-CLM) session-based recommendation model with multiple features"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5b7eee2b",
+   "id": "518a0cc8",
    "metadata": {},
    "source": [
     "## Build a DL model with Transformers4Rec library  "
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3afdd23",
+   "id": "63a0ae39",
    "metadata": {},
    "source": [
     "Transformers4Rec supports multiple input features and provides configurable building blocks that can be easily combined for custom architectures:\n",
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1b04b39",
+   "id": "dd2a330f",
    "metadata": {},
    "source": [
     "Figure 1 illustrates Transformers4Rec meta-architecture and how each module/block interacts with each other."
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfef2d12",
+   "id": "3bafd4c2",
    "metadata": {},
    "source": [
     "![tf4rec_meta](images/tf4rec_meta2.png)"
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da37e6d3",
+   "id": "3b8e6bca",
    "metadata": {},
    "source": [
     "### Imports required libraries"
@@ -104,16 +104,16 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "481426d9",
+   "id": "2ae49de1",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-11-17 19:15:27.849759: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "2021-11-18 16:30:19.596179: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2021-11-17 19:15:29.625089: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1510] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 8080 MB memory:  -> device: 0, name: Tesla V100-SXM2-16GB-N, pci bus id: 0000:0b:00.0, compute capability: 7.0\n"
+      "2021-11-18 16:30:21.358586: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1510] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 8080 MB memory:  -> device: 0, name: Tesla V100-SXM2-16GB-N, pci bus id: 0000:0b:00.0, compute capability: 7.0\n"
      ]
     }
    ],
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33be17c5",
+   "id": "477cc905",
    "metadata": {},
    "source": [
     "Transformers4Rec library relies on a schema object to automatically build all necessary layers to represent, normalize and aggregate input features. As you can see below, `schema.pb` is a protobuf file that contains metadata including statistics about features such as cardinality, min and max values and also tags features based on their characteristics and dtypes (e.g., categorical, continuous, list, integer)."
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22d9599e",
+   "id": "e101b71c",
    "metadata": {},
    "source": [
     "### Manually set the schema "
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9e4a6ef8",
+   "id": "52a20432",
    "metadata": {},
    "outputs": [
     {
@@ -256,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "054bb34e",
+   "id": "871d515b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "991791f2",
+   "id": "26b9302e",
    "metadata": {},
    "source": [
     "### Define the sequential input module"
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b4229e9",
+   "id": "20be9964",
    "metadata": {},
    "source": [
     "Below we define our `input` block using the `TabularSequenceFeatures` [class](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/main/transformers4rec/tf/features/sequence.py#L121). The `from_schema()` method processes the schema and creates the necessary layers to represent features and aggregate them. It keeps only features tagged as `categorical` and `continuous` and supports data aggregation methods like `concat` and `elementwise-sum` techniques. It also support data augmentation techniques like stochastic swap noise. It outputs an interaction representation after combining all features and also the input mask according to the training task (more on this later).\n"
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1f1772c",
+   "id": "3c912a9a",
    "metadata": {},
    "source": [
     "The `max_sequence_length` argument defines the maximum sequence length of our sequential input, and if `continuous_projection` argument is set, all numerical features are concatenated and projected by an MLP block so that continuous features are represented by a vector of size defined by user, which is `64` in this example."
@@ -294,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "4f9d7c18",
+   "id": "da17ea3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49f6380e",
+   "id": "ee072b1c",
    "metadata": {},
    "source": [
     "The output of the `TabularSequenceFeatures` module is the sequence of interactions embeddings vectors defined in the following steps:\n",
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1b31049",
+   "id": "e347a744",
    "metadata": {},
    "source": [
     "### Define the Transformer Block"
@@ -330,7 +330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd4c6a8e",
+   "id": "3239040f",
    "metadata": {},
    "source": [
     "In the next cell, the whole model is build with a few lines of code. \n",
@@ -343,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "da77bb18",
+   "id": "e24e0e6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c937391",
+   "id": "cafc8f0a",
    "metadata": {},
    "source": [
     "### Train the model "
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09390aaa",
+   "id": "a7a073cf",
    "metadata": {},
    "source": [
     "We use the NVTabular `KerasSequenceLoader` Dataloader for optimized loading of multiple features from input parquet files. You can learn more about this data loader [here](https://nvidia-merlin.github.io/NVTabular/main/training/tensorflow.html)."
@@ -386,7 +386,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44919132",
+   "id": "1711d7a6",
    "metadata": {},
    "source": [
     "### **Set DataLoader**"
@@ -395,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "b64fcad1",
+   "id": "e468a433",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30948503",
+   "id": "395deb08",
    "metadata": {},
    "source": [
     "## Set training params"
@@ -432,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ad3b7571",
+   "id": "c375eeeb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c13ef04",
+   "id": "4b902bc8",
    "metadata": {},
    "source": [
     "## Daily Fine-Tuning: Training over a time window"
@@ -454,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "126035e4",
+   "id": "4b804f1b",
    "metadata": {},
    "source": [
     "Here we do daily fine-tuning meaning that we use the first day to train and second day to evaluate, then we use the second day data to train the model by resuming from the first step, and evaluate on the third day, so on so forth."
@@ -462,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1d75967",
+   "id": "9ff9b209",
    "metadata": {},
    "source": [
     "- Define the output folder of the processed parquet files"
@@ -471,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "1d65282f",
+   "id": "811f6121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,19 +480,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "40761b6d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from transformers import logging\n",
-    "logging.set_verbosity_error()"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 11,
-   "id": "141c961f",
+   "id": "a4a0572a",
    "metadata": {},
    "outputs": [
     {
@@ -509,8 +498,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-11-17 19:15:37.980096: I tensorflow/stream_executor/cuda/cuda_dnn.cc:369] Loaded cuDNN version 8204\n",
-      "2021-11-17 19:15:38.196940: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:185] None of the MLIR Optimization Passes are enabled (registered 2)\n"
+      "2021-11-18 16:30:29.316737: I tensorflow/stream_executor/cuda/cuda_dnn.cc:369] Loaded cuDNN version 8204\n",
+      "2021-11-18 16:30:29.540981: I tensorflow/compiler/mlir/mlir_graph_optimization_pass.cc:185] None of the MLIR Optimization Passes are enabled (registered 2)\n"
      ]
     },
     {
@@ -518,55 +507,55 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/5\n",
-      "15/15 [==============================] - 34s 2s/step - train_ndcg@20: 0.0032 - train_ndcg@40: 0.0044 - train_recall@20: 0.0099 - train_recall@40: 0.0155 - loss: 10.7448 - regularization_loss: 0.0000e+00 - total_loss: 10.7448\n",
+      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.0030 - train_ndcg@40: 0.0046 - train_recall@20: 0.0078 - train_recall@40: 0.0160 - loss: 10.7693 - regularization_loss: 0.0000e+00 - total_loss: 10.7693\n",
       "Epoch 2/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.0675 - train_ndcg@40: 0.0794 - train_recall@20: 0.1586 - train_recall@40: 0.2161 - loss: 9.0805 - regularization_loss: 0.0000e+00 - total_loss: 9.0805\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.0685 - train_ndcg@40: 0.0802 - train_recall@20: 0.1480 - train_recall@40: 0.2050 - loss: 9.1048 - regularization_loss: 0.0000e+00 - total_loss: 9.1048\n",
       "Epoch 3/5\n",
-      "15/15 [==============================] - 34s 2s/step - train_ndcg@20: 0.1308 - train_ndcg@40: 0.1669 - train_recall@20: 0.3277 - train_recall@40: 0.5055 - loss: 7.3849 - regularization_loss: 0.0000e+00 - total_loss: 7.3849\n",
+      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1363 - train_ndcg@40: 0.1695 - train_recall@20: 0.3396 - train_recall@40: 0.5022 - loss: 7.4349 - regularization_loss: 0.0000e+00 - total_loss: 7.4349\n",
       "Epoch 4/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1479 - train_ndcg@40: 0.1922 - train_recall@20: 0.3941 - train_recall@40: 0.6113 - loss: 5.9321 - regularization_loss: 0.0000e+00 - total_loss: 5.9321\n",
+      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1542 - train_ndcg@40: 0.1966 - train_recall@20: 0.4040 - train_recall@40: 0.6110 - loss: 5.9372 - regularization_loss: 0.0000e+00 - total_loss: 5.9372\n",
       "Epoch 5/5\n",
-      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1697 - train_ndcg@40: 0.2185 - train_recall@20: 0.4360 - train_recall@40: 0.6740 - loss: 5.0944 - regularization_loss: 0.0000e+00 - total_loss: 5.0944\n",
-      "2/2 [==============================] - 1s 290ms/step - eval_ndcg@20: 0.1736 - eval_ndcg@40: 0.2243 - eval_recall@20: 0.5006 - eval_recall@40: 0.7477 - loss: 4.7323 - regularization_loss: 0.0000e+00 - total_loss: 4.7323\n",
+      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1639 - train_ndcg@40: 0.2163 - train_recall@20: 0.4244 - train_recall@40: 0.6806 - loss: 5.1375 - regularization_loss: 0.0000e+00 - total_loss: 5.1375\n",
+      "2/2 [==============================] - 1s 296ms/step - eval_ndcg@20: 0.1827 - eval_ndcg@40: 0.2315 - eval_recall@20: 0.4877 - eval_recall@40: 0.7256 - loss: 4.7567 - regularization_loss: 0.0000e+00 - total_loss: 4.7567\n",
       "********************\n",
       "Eval results for day 2 are:\t\n",
       "\n",
       "********************\n",
       "\n",
-      " eval_ndcg@20 = 0.18473437428474426\n",
-      " eval_ndcg@40 = 0.2354496419429779\n",
-      " eval_recall@20 = 0.5087719559669495\n",
-      " eval_recall@40 = 0.7543859481811523\n",
-      " loss = 4.700231075286865\n",
+      " eval_ndcg@20 = 0.1788734793663025\n",
+      " eval_ndcg@40 = 0.2327456772327423\n",
+      " eval_recall@20 = 0.4736842215061188\n",
+      " eval_recall@40 = 0.7368420958518982\n",
+      " loss = 4.716386795043945\n",
       " regularization_loss = 0\n",
-      " total_loss = 4.700231075286865\n",
+      " total_loss = 4.716386795043945\n",
       "********************\n",
       "Launch training for day 2 are:\n",
       "********************\n",
       "\n",
       "Epoch 1/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1660 - train_ndcg@40: 0.2242 - train_recall@20: 0.4339 - train_recall@40: 0.7177 - loss: 4.8249 - regularization_loss: 0.0000e+00 - total_loss: 4.8249\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1685 - train_ndcg@40: 0.2231 - train_recall@20: 0.4700 - train_recall@40: 0.7368 - loss: 4.8112 - regularization_loss: 0.0000e+00 - total_loss: 4.8112\n",
       "Epoch 2/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1672 - train_ndcg@40: 0.2227 - train_recall@20: 0.4604 - train_recall@40: 0.7327 - loss: 4.7189 - regularization_loss: 0.0000e+00 - total_loss: 4.7189\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1680 - train_ndcg@40: 0.2213 - train_recall@20: 0.4611 - train_recall@40: 0.7229 - loss: 4.7283 - regularization_loss: 0.0000e+00 - total_loss: 4.7283\n",
       "Epoch 3/5\n",
-      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1736 - train_ndcg@40: 0.2282 - train_recall@20: 0.4633 - train_recall@40: 0.7310 - loss: 4.6492 - regularization_loss: 0.0000e+00 - total_loss: 4.6492\n",
+      "15/15 [==============================] - 31s 2s/step - train_ndcg@20: 0.1720 - train_ndcg@40: 0.2265 - train_recall@20: 0.4640 - train_recall@40: 0.7306 - loss: 4.6544 - regularization_loss: 0.0000e+00 - total_loss: 4.6544\n",
       "Epoch 4/5\n",
-      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1692 - train_ndcg@40: 0.2260 - train_recall@20: 0.4542 - train_recall@40: 0.7322 - loss: 4.6401 - regularization_loss: 0.0000e+00 - total_loss: 4.6401\n",
+      "15/15 [==============================] - 32s 2s/step - train_ndcg@20: 0.1723 - train_ndcg@40: 0.2295 - train_recall@20: 0.4582 - train_recall@40: 0.7385 - loss: 4.6317 - regularization_loss: 0.0000e+00 - total_loss: 4.6317\n",
       "Epoch 5/5\n",
-      "15/15 [==============================] - 34s 2s/step - train_ndcg@20: 0.1770 - train_ndcg@40: 0.2323 - train_recall@20: 0.4653 - train_recall@40: 0.7359 - loss: 4.6038 - regularization_loss: 0.0000e+00 - total_loss: 4.6038\n",
-      "2/2 [==============================] - 1s 249ms/step - eval_ndcg@20: 0.1778 - eval_ndcg@40: 0.2368 - eval_recall@20: 0.4613 - eval_recall@40: 0.7501 - loss: 4.4416 - regularization_loss: 0.0000e+00 - total_loss: 4.4416\n",
+      "15/15 [==============================] - 33s 2s/step - train_ndcg@20: 0.1673 - train_ndcg@40: 0.2254 - train_recall@20: 0.4533 - train_recall@40: 0.7367 - loss: 4.6163 - regularization_loss: 0.0000e+00 - total_loss: 4.6163\n",
+      "2/2 [==============================] - 1s 254ms/step - eval_ndcg@20: 0.1643 - eval_ndcg@40: 0.2186 - eval_recall@20: 0.4822 - eval_recall@40: 0.7501 - loss: 4.4777 - regularization_loss: 0.0000e+00 - total_loss: 4.4777\n",
       "********************\n",
       "Eval results for day 3 are:\t\n",
       "\n",
       "********************\n",
       "\n",
-      " eval_ndcg@20 = 0.1962771713733673\n",
-      " eval_ndcg@40 = 0.24134907126426697\n",
+      " eval_ndcg@20 = 0.17018109560012817\n",
+      " eval_ndcg@40 = 0.21519054472446442\n",
       " eval_recall@20 = 0.4888888895511627\n",
       " eval_recall@40 = 0.7111111283302307\n",
-      " loss = 4.488396644592285\n",
+      " loss = 4.539609909057617\n",
       " regularization_loss = 0\n",
-      " total_loss = 4.488396644592285\n"
+      " total_loss = 4.539609909057617\n"
      ]
     }
    ],
@@ -600,7 +589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dae1bbe1",
+   "id": "3a59e7b9",
    "metadata": {},
    "source": [
     "### Saves the model"
@@ -609,14 +598,14 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "a9129885",
+   "id": "e60a0e15",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-11-17 19:21:22.282683: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+      "2021-11-18 16:36:05.689344: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
      ]
     }
    ],
@@ -626,7 +615,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea49aa5d",
+   "id": "9da34948",
    "metadata": {},
    "source": [
     "### Reloads the model"
@@ -635,7 +624,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "7f5f69dc",
+   "id": "44f4436c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "3cca4090",
+   "id": "cef7197b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -655,26 +644,26 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "e471504d",
+   "id": "93a0f974",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "<tf.Tensor: shape=(64, 50006), dtype=float32, numpy=\n",
-       "array([[-14.483589 , -15.827689 ,  -3.2657387, ..., -15.472676 ,\n",
-       "        -14.786966 , -15.284707 ],\n",
-       "       [-14.517188 , -15.770086 ,  -3.3817382, ..., -15.530424 ,\n",
-       "        -14.766118 , -15.170356 ],\n",
-       "       [-14.461672 , -15.592571 ,  -3.2989364, ..., -15.317642 ,\n",
-       "        -14.794083 , -15.200134 ],\n",
+       "array([[-14.886165 , -15.133767 ,  -3.1503913, ..., -15.143302 ,\n",
+       "        -14.165563 , -13.621665 ],\n",
+       "       [-14.905037 , -15.140341 ,  -3.1269689, ..., -15.163202 ,\n",
+       "        -14.157326 , -13.655285 ],\n",
+       "       [-14.849622 , -15.11325  ,  -3.2750463, ..., -15.082913 ,\n",
+       "        -14.251033 , -13.546626 ],\n",
        "       ...,\n",
-       "       [-14.512834 , -15.774984 ,  -3.2765167, ..., -15.475362 ,\n",
-       "        -14.711787 , -15.197722 ],\n",
-       "       [-14.5886345, -15.740798 ,  -3.3435194, ..., -15.510273 ,\n",
-       "        -14.731354 , -15.161112 ],\n",
-       "       [-14.604326 , -15.766655 ,  -3.3291552, ..., -15.422941 ,\n",
-       "        -14.72044  , -15.21335  ]], dtype=float32)>"
+       "       [-14.884882 , -15.14102  ,  -3.3538773, ..., -15.109003 ,\n",
+       "        -14.1946745, -13.515995 ],\n",
+       "       [-14.798379 , -15.08512  ,  -3.2425992, ..., -15.098843 ,\n",
+       "        -14.163866 , -13.492168 ],\n",
+       "       [-14.90872  , -15.083946 ,  -3.319263 , ..., -15.099293 ,\n",
+       "        -14.140776 , -13.505323 ]], dtype=float32)>"
       ]
      },
      "execution_count": 15,
@@ -688,7 +677,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1359e70b",
+   "id": "feb1bc78",
    "metadata": {},
    "source": [
     "That's it!  \n",

--- a/tests/tf/test_ranking_metrics.py
+++ b/tests/tf/test_ranking_metrics.py
@@ -59,6 +59,15 @@ def test_score_different_from_zero(tf_ranking_metrics_inputs, metric):
     assert all(e > 0 for e in result)
 
 
+@pytest.mark.parametrize("metric", list_metrics)
+def test_score_different_between_thresholds(tf_ranking_metrics_inputs, metric):
+    metric = tr.ranking_metric.ranking_metrics_registry[metric](top_ks=[5, 20], labels_onehot=True)
+    result = metric(
+        y_pred=tf_ranking_metrics_inputs["scores"], y_true=tf_ranking_metrics_inputs["labels"]
+    )
+    assert result[-1] != result[0]
+
+
 # compare implemented metrics w.r.t tensorflow_ranking
 metrics_to_compare = [
     (tfr.keras.metrics.RecallMetric, "recall"),

--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -358,7 +358,9 @@ def process_metrics(metrics, prefix=""):
         if getattr(metric, "top_ks", None):
             for i, ks in enumerate(metric.top_ks):
 
-                metrics_proc.update({f"{prefix}{metric.name}{ks}": tf.gather(results, i)})
+                metrics_proc.update(
+                    {f"{prefix}{metric.name.split('_')[0]}@{ks}": tf.gather(results, i)}
+                )
         else:
             metrics_proc[metric.name] = results
     return metrics_proc

--- a/transformers4rec/tf/ranking_metric.py
+++ b/transformers4rec/tf/ranking_metric.py
@@ -330,7 +330,9 @@ class NDCGAt(RankingMetric):
         relevant_pos = tf.where(normalizing_gains != 0)
         tf.where(normalizing_gains == 0, 0.0, gains)
 
-        updates = tf.gather_nd(gains, relevant_pos) / tf.gather_nd(normalizing_gains, relevant_pos)
+        updates = tf.gather_nd(self.accumulator, relevant_pos) / tf.gather_nd(
+            normalizing_gains, relevant_pos
+        )
         self.accumulator.scatter_nd_update(relevant_pos, updates)
 
 
@@ -355,6 +357,7 @@ def process_metrics(metrics, prefix=""):
         results = metric.result()
         if getattr(metric, "top_ks", None):
             for i, ks in enumerate(metric.top_ks):
+
                 metrics_proc.update({f"{prefix}{metric.name}{ks}": tf.gather(results, i)})
         else:
             metrics_proc[metric.name] = results


### PR DESCRIPTION
### Goals :soccer:
- The PR introduces the first example of getting-started notebook using Tensorflow API. 

### Implementation Details :construction:
-  Add the first version of the getting-started notebook for TensorFlow, similar to the one we have in pytorch API.
- Some issues were raised when defining the notebook: 

     - `NDCG` metric was returning the same score for all thresholds: This was related to the fact that `gains` and `normalized_gains` are pointing to the same variable `self.accumulator` of DCGAt metric and therefore taking the same value. It was fixed by using the self.accumulator of the NDCGAt instead of gains when computing the updates. 
   
     -  Update `process_metrics` to print the ranking metrics in the same format we used for pytorch API. 
     
     - `mlm` is leading to evaluation scores close to 1 and the issue (#333 ) will be tracked in a different PR. 

### Testing Details :mag:
- Add a unit test that checks if the ranking scores of different thresholds are not equal. 
