### PR TITLE
Quick fix of the value returned by fit_and_evaluate

### DIFF
--- a/examples/end-to-end-session-based/end-to-end-session-based-with-Yoochoose.ipynb
+++ b/examples/end-to-end-session-based/end-to-end-session-based-with-Yoochoose.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "8108b211",
+   "id": "80592ba7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76421714",
+   "id": "9ac2bcac",
    "metadata": {
     "tags": []
    },
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "916719d3",
+   "id": "1e4e7e38",
    "metadata": {},
    "source": [
     "In recent years, several deep learning-based algorithms have been proposed for recommendation systems while its adoption in industry deployments have been steeply growing. In particular, NLP inspired approaches have been successfully adapted for sequential and session-based recommendation problems, which are important for many domains like e-commerce, news and streaming media. Session-Based Recommender Systems (SBRS) have been proposed to model the sequence of interactions within the current user session, where a session is a short sequence of user interactions typically bounded by user inactivity. They have recently gained popularity due to their ability to capture short-term or contextual user preferences towards items. \n",
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b24dd14d",
+   "id": "dd065f3f",
    "metadata": {},
    "source": [
     "## 1. Setup"
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1360ccb2",
+   "id": "2588c0f6",
    "metadata": {},
    "source": [
     "### 1.1. Import Libraries and Define Data Input and Output Paths"
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "790dfa63",
+   "id": "20b63545",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "880e5250",
+   "id": "3012406f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d07dbd85",
+   "id": "c1ddd5c0",
    "metadata": {},
    "source": [
     "### 1.2. Download the data"
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a55f498",
+   "id": "a0b665ce",
    "metadata": {},
    "source": [
     "In this notebook we are using the `YOOCHOOSE` dataset which contains a collection of sessions from a retailer. Each session  encapsulates the click events that the user performed in that session.\n",
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "060f2781",
+   "id": "e6a9aca7",
    "metadata": {},
    "source": [
     "### 1.3. Load and clean raw data"
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9741bf12",
+   "id": "253d62f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f35855b",
+   "id": "77a91ae7",
    "metadata": {},
    "source": [
     "#### Remove repeated interactions within the same session"
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "2e476761",
+   "id": "06f85281",
    "metadata": {
     "tags": []
    },
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0328cd64",
+   "id": "12cbc702",
    "metadata": {},
    "source": [
     "#### Creates new feature with the timestamp when the item was first seen"
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a0848f57",
+   "id": "ad86808e",
    "metadata": {
     "tags": []
    },
@@ -215,43 +215,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>549</td>\n",
-       "      <td>1396774534</td>\n",
-       "      <td>214714927</td>\n",
+       "      <td>7239</td>\n",
+       "      <td>1396902913</td>\n",
+       "      <td>214640017</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396334996</td>\n",
+       "      <td>1396332599</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>549</td>\n",
-       "      <td>1396774556</td>\n",
-       "      <td>214517450</td>\n",
+       "      <td>7239</td>\n",
+       "      <td>1396902984</td>\n",
+       "      <td>214827011</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396329825</td>\n",
+       "      <td>1396735848</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>549</td>\n",
-       "      <td>1396774617</td>\n",
-       "      <td>214714929</td>\n",
+       "      <td>7241</td>\n",
+       "      <td>1396551702</td>\n",
+       "      <td>214820450</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396341783</td>\n",
+       "      <td>1396326153</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>549</td>\n",
-       "      <td>1396774647</td>\n",
-       "      <td>214518555</td>\n",
+       "      <td>7242</td>\n",
+       "      <td>1396878372</td>\n",
+       "      <td>214552633</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396327272</td>\n",
+       "      <td>1396373414</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>549</td>\n",
-       "      <td>1396774664</td>\n",
-       "      <td>214639297</td>\n",
+       "      <td>7242</td>\n",
+       "      <td>1396879067</td>\n",
+       "      <td>214839827</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396353119</td>\n",
+       "      <td>1396357542</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -259,11 +259,11 @@
       ],
       "text/plain": [
        "   session_id   timestamp    item_id  category  itemid_ts_first\n",
-       "0         549  1396774534  214714927         0       1396334996\n",
-       "1         549  1396774556  214517450         0       1396329825\n",
-       "2         549  1396774617  214714929         0       1396341783\n",
-       "3         549  1396774647  214518555         0       1396327272\n",
-       "4         549  1396774664  214639297         0       1396353119"
+       "0        7239  1396902913  214640017         0       1396332599\n",
+       "1        7239  1396902984  214827011         0       1396735848\n",
+       "2        7241  1396551702  214820450         0       1396326153\n",
+       "3        7242  1396878372  214552633         0       1396373414\n",
+       "4        7242  1396879067  214839827         0       1396357542"
       ]
      },
      "execution_count": 6,
@@ -280,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "b116d046",
+   "id": "57c2cda1",
    "metadata": {
     "tags": []
    },
@@ -304,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abbd5ef7",
+   "id": "a1f1526e",
    "metadata": {},
    "source": [
     "## 2. Define a preprocessing workflow with NVTabular"
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a3d83c8d",
+   "id": "6aa9514f",
    "metadata": {},
    "source": [
     "NVTabular is a feature engineering and preprocessing library for tabular data designed to quickly and easily manipulate terabyte scale datasets used to train deep learning based recommender systems. It provides a high level abstraction to simplify code and accelerates computation on the GPU using the RAPIDS cuDF library.\n",
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c21f3dac",
+   "id": "ea4efdb6",
    "metadata": {},
    "source": [
     "### 2.1 Feature engineering: Create and Transform items features"
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47ece553",
+   "id": "ca96ae08",
    "metadata": {},
    "source": [
     "In this cell, we are defining three transformations ops: \n",
@@ -347,7 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2c1620e3",
+   "id": "f25800a0",
    "metadata": {
     "tags": []
    },
@@ -409,7 +409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "343ce466",
+   "id": "2e8bc1ae",
    "metadata": {},
    "source": [
     "### 2.2 Defines the preprocessing of sequential features"
@@ -417,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b397a1c",
+   "id": "7dd429b2",
    "metadata": {},
    "source": [
     "Once the item features are generated, the objective of this cell is grouping interactions at the session level, sorting the interactions by time. We additionally truncate all sessions to first 20 interactions and filter out sessions with less than 2 interactions."
@@ -426,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c15cae90",
+   "id": "3dfd51bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c902ae1",
+   "id": "127623cf",
    "metadata": {},
    "source": [
     "- Avoid Numba low occupancy warnings"
@@ -475,8 +475,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "82c0fb47",
+   "execution_count": 10,
+   "id": "eb54a436",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +486,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "872492c4",
+   "id": "c294ae96",
    "metadata": {},
    "source": [
     "### 2.3 Execute NVTabular workflow"
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c5390d0",
+   "id": "2c18671f",
    "metadata": {},
    "source": [
     "Once we have defined the general workflow (`filtered_sessions`), we provide our cudf dataset to nvt.Dataset class which is optimized to split data into chunks that can fit in device memory and to handle the calculation of complex global statistics. Then, we execute the pipeline that fits and transforms data to get the desired output features."
@@ -502,8 +502,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "185f2759",
+   "execution_count": 11,
+   "id": "9730c19b",
    "metadata": {
     "tags": []
    },
@@ -519,7 +519,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88627f9d",
+   "id": "26c4418c",
    "metadata": {},
    "source": [
     "Let's print the head of our preprocessed dataset. You can notice that now each example (row) is a session and the sequential features with respect to user interactions were converted to lists with matching length."
@@ -527,8 +527,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "acd67e9f",
+   "execution_count": 12,
+   "id": "f22e5e61",
    "metadata": {
     "tags": []
    },
@@ -655,7 +655,7 @@
        "4  [1.3714824, 1.3715883, 1.3715737, 1.3715955, 1...        149  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -666,7 +666,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a08cb37",
+   "id": "fe280635",
    "metadata": {},
    "source": [
     "#### Saves the preprocessing workflow"
@@ -674,8 +674,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "aec9d6c3",
+   "execution_count": 13,
+   "id": "faa4a886",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,7 +684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9185bb30",
+   "id": "d3be0df8",
    "metadata": {},
    "source": [
     "### 2.4 Export pre-processed data by day"
@@ -692,7 +692,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7aef05ce",
+   "id": "cf8cc025",
    "metadata": {},
    "source": [
     "In this example we are going to split the preprocessed parquet files by days, to allow for temporal training and evaluation. There will be a folder for each day and three parquet files within each day: `train.parquet`, `validation.parquet` and `test.parquet`\n",
@@ -702,8 +702,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "04176356",
+   "execution_count": 14,
+   "id": "43c69589",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -712,8 +712,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "07067c7e",
+   "execution_count": 15,
+   "id": "75ce8ba4",
    "metadata": {
     "tags": []
    },
@@ -722,7 +722,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Creating time-based splits: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00,  5.64it/s]\n"
+      "Creating time-based splits: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00,  8.28it/s]\n"
      ]
     }
    ],
@@ -737,8 +737,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "e058a369",
+   "execution_count": 16,
+   "id": "419d60de",
    "metadata": {
     "tags": []
    },
@@ -748,11 +748,7 @@
      "output_type": "stream",
      "text": [
       "preproc_sessions_by_day/\n",
-      "    180/\n",
-      "        test.parquet\n",
-      "        valid.parquet\n",
-      "        train.parquet\n",
-      "    181/\n",
+      "    182/\n",
       "        test.parquet\n",
       "        valid.parquet\n",
       "        train.parquet\n",
@@ -760,11 +756,15 @@
       "        test.parquet\n",
       "        valid.parquet\n",
       "        train.parquet\n",
-      "    182/\n",
+      "    180/\n",
       "        test.parquet\n",
       "        valid.parquet\n",
       "        train.parquet\n",
       "    178/\n",
+      "        test.parquet\n",
+      "        valid.parquet\n",
+      "        train.parquet\n",
+      "    181/\n",
       "        test.parquet\n",
       "        valid.parquet\n",
       "        train.parquet\n"
@@ -778,8 +778,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "55b58f39",
+   "execution_count": 17,
+   "id": "8e3f0f05",
    "metadata": {
     "tags": []
    },
@@ -790,7 +790,7 @@
        "0"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -803,7 +803,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "015d14a5",
+   "id": "853d9f9c",
    "metadata": {},
    "source": [
     "## 3. Model definition using Transformers4Rec"
@@ -811,7 +811,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c1b9492",
+   "id": "646422f1",
    "metadata": {},
    "source": [
     "### 3.1 Get the schema "
@@ -819,7 +819,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e2aa3f0",
+   "id": "96d9a87e",
    "metadata": {},
    "source": [
     "The library uses a schema format to configure the input features and automatically creates the necessary layers. This *protobuf* text file contains the description of each input feature by defining: the name, the type, the number of elements of a list column,  the cardinality of a categorical feature and the min and max values of each feature. In addition, the annotation field contains the tags such as specifying `continuous` and `categorical` features, the `target` column or the `item_id` feature, among others."
@@ -827,8 +827,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "0b98e462",
+   "execution_count": 18,
+   "id": "277a5969",
    "metadata": {
     "tags": []
    },
@@ -837,6 +837,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "feature {\n",
+      "  name: \"session_id\"\n",
+      "  type: INT\n",
+      "  int_domain {\n",
+      "    name: \"session_id\"\n",
+      "    min: 1\n",
+      "    max: 9249733 \n",
+      "    is_categorical: false\n",
+      "  }\n",
+      "  annotation {\n",
+      "    tag: \"groupby_col\"\n",
+      "  }\n",
+      "}\n",
       "feature {\n",
       "  name: \"item_id-list_seq\"\n",
       "  value_count {\n",
@@ -855,19 +868,6 @@
       "    tag: \"list\"\n",
       "    tag: \"categorical\"\n",
       "    tag: \"item\"\n",
-      "  }\n",
-      "}\n",
-      "feature {\n",
-      "  name: \"session_id\"\n",
-      "  type: INT\n",
-      "  int_domain {\n",
-      "    name: \"session_id\"\n",
-      "    min: 1\n",
-      "    max: 9249733 \n",
-      "    is_categorical: false\n",
-      "  }\n",
-      "  annotation {\n",
-      "    tag: \"groupby_col\"\n",
       "  }\n",
       "}\n",
       "feature {\n",
@@ -919,6 +919,7 @@
       "    max: 0.9995285\n",
       "  }\n",
       "  annotation {\n",
+      "    tag: \"continuous\"\n",
       "    tag: \"time\"\n",
       "    tag: \"list\"\n",
       "  }\n",
@@ -935,7 +936,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c88641c",
+   "id": "185452cb",
    "metadata": {},
    "source": [
     "We can select the subset of features we want to use for training the model by their tags or their names."
@@ -943,8 +944,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "32c0ede1",
+   "execution_count": 19,
+   "id": "60698c61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -955,7 +956,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f668c2d",
+   "id": "e3f049c7",
    "metadata": {},
    "source": [
     "### 3.2 Define the end-to-end Session-based Transformer-based recommendation model"
@@ -963,7 +964,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42aa9ee9",
+   "id": "d6411cfa",
    "metadata": {
     "tags": []
    },
@@ -983,8 +984,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "5f48ba32",
+   "execution_count": 20,
+   "id": "527c7389",
    "metadata": {
     "tags": []
    },
@@ -1025,8 +1026,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "e90f69c6",
+   "execution_count": 21,
+   "id": "63472254",
    "metadata": {
     "tags": []
    },
@@ -1048,7 +1049,7 @@
        "              )\n",
        "              (1): SequentialBlock(\n",
        "                (0): DenseBlock(\n",
-       "                  (0): Linear(in_features=1, out_features=64, bias=True)\n",
+       "                  (0): Linear(in_features=2, out_features=64, bias=True)\n",
        "                  (1): ReLU(inplace=True)\n",
        "                )\n",
        "              )\n",
@@ -1148,7 +1149,7 @@
        ")"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1159,7 +1160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb3e5a39",
+   "id": "707bcb90",
    "metadata": {},
    "source": [
     "### 3.3. Daily Fine-Tuning: Training over a time window¶"
@@ -1167,7 +1168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb1e05a6",
+   "id": "c669fd97",
    "metadata": {},
    "source": [
     "Now that the model is defined, we are going to launch training. For that, Transfromers4rec extends HF Transformers Trainer class to adapt the evaluation loop for session-based recommendation task and the calculation of ranking metrics. The original `train()` method is not modified meaning that we leverage the efficient training implementation from that library, which manages for example half-precision (FP16) training."
@@ -1175,7 +1176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e55dbd4",
+   "id": "4f845f95",
    "metadata": {},
    "source": [
     "#### Sets Training arguments"
@@ -1183,7 +1184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "172b6d9a",
+   "id": "eac11371",
    "metadata": {},
    "source": [
     "An additional argument `data_loader_engine` is defined to automatically load the features needed for training using the schema. The default value is `nvtabular` for optimized GPU-based data-loading.  Optionally a `PyarrowDataLoader` (`pyarrow`) can also be used as a basic option, but it is slower and works only for small datasets, as the full data is loaded to CPU memory."
@@ -1191,8 +1192,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "23bfa8d9",
+   "execution_count": 22,
+   "id": "cc635ebd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1213,7 +1214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "845e8cac",
+   "id": "5a2a6d41",
    "metadata": {},
    "source": [
     "#### Instantiate the trainer"
@@ -1221,8 +1222,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "4d8ba34d",
+   "execution_count": 23,
+   "id": "3bf1e68e",
    "metadata": {
     "tags": []
    },
@@ -1245,7 +1246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2189f1a3",
+   "id": "e0faecc0",
    "metadata": {},
    "source": [
     "#### Launches daily Training and Evaluation"
@@ -1253,16 +1254,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06c017e1",
+   "id": "ce43d452",
    "metadata": {},
    "source": [
-    "In this demo, we will use the `fit_and_evaluate` method that allows us to conduct a time-based finetuning by iteratively training and evaluating using a sliding time window: At each iteration, we use training data of a specific time index $t$ to train the model then we evaluate on the validation data of next index $t + 1$. Particularly, the start time is set to 178 and end time to 180."
+    "In this demo, we will use the `fit_and_evaluate` method that allows us to conduct a time-based finetuning by iteratively training and evaluating using a sliding time window: At each iteration, we use training data of a specific time index $t$ to train the model then we evaluate on the validation data of next index $t + 1$. Particularly, both the start and end time is set to 178."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "ffb7421b",
+   "execution_count": 24,
+   "id": "c8018840",
    "metadata": {
     "tags": []
    },
@@ -1275,7 +1276,7 @@
       "  Num examples = 28800\n",
       "  Num Epochs = 10\n",
       "  Instantaneous batch size per device = 384\n",
-      "  Total train batch size (w. parallel, distributed & accumulation) = 1536\n",
+      "  Total train batch size (w. parallel, distributed & accumulation) = 384\n",
       "  Gradient Accumulation steps = 1\n",
       "  Total optimization steps = 750\n"
      ]
@@ -1295,7 +1296,7 @@
        "    <div>\n",
        "      \n",
        "      <progress value='750' max='750' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [750/750 00:31, Epoch 10/10]\n",
+       "      [750/750 00:28, Epoch 10/10]\n",
        "    </div>\n",
        "    <table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -1307,15 +1308,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>200</td>\n",
-       "      <td>7.807600</td>\n",
+       "      <td>7.710400</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>400</td>\n",
-       "      <td>6.737500</td>\n",
+       "      <td>6.630000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>600</td>\n",
-       "      <td>6.462300</td>\n",
+       "      <td>6.327400</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -1365,12 +1366,12 @@
       "\n",
       "***** Evaluation results for day 179:*****\n",
       "\n",
-      " eval/next-item/avg_precision_@10 = 0.06432348489761353\n",
-      " eval/next-item/avg_precision_@20 = 0.06879562139511108\n",
-      " eval/next-item/ndcg_@10 = 0.09142451733350754\n",
-      " eval/next-item/ndcg_@20 = 0.10751541703939438\n",
-      " eval/next-item/recall_@10 = 0.17764931917190552\n",
-      " eval/next-item/recall_@20 = 0.24123314023017883\n"
+      " eval/next-item/avg_precision@10 = 0.08277411013841629\n",
+      " eval/next-item/avg_precision@20 = 0.08782819658517838\n",
+      " eval/next-item/ndcg@10 = 0.11141632497310638\n",
+      " eval/next-item/ndcg@20 = 0.1303318589925766\n",
+      " eval/next-item/recall@10 = 0.20154142379760742\n",
+      " eval/next-item/recall@20 = 0.2774566411972046\n"
      ]
     }
    ],
@@ -1381,7 +1382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b555d34",
+   "id": "31e6cf87",
    "metadata": {
     "tags": []
    },
@@ -1390,9 +1391,43 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a726ee60",
+   "metadata": {},
+   "source": [
+    "`aot_results` is a list of scores (accuracy metrics) for evaluation based on given start and end time_index. Since in this example we do evaluation only on day 179, we only get one metric in the list."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "a3759c15",
+   "execution_count": 26,
+   "id": "2ed03be9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'indexed_by_time_eval/next-item/avg_precision@10': [0.08277411013841629],\n",
+       " 'indexed_by_time_eval/next-item/avg_precision@20': [0.08782819658517838],\n",
+       " 'indexed_by_time_eval/next-item/ndcg@10': [0.11141632497310638],\n",
+       " 'indexed_by_time_eval/next-item/ndcg@20': [0.1303318589925766],\n",
+       " 'indexed_by_time_eval/next-item/recall@10': [0.20154142379760742],\n",
+       " 'indexed_by_time_eval/next-item/recall@20': [0.2774566411972046]}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "aot_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "7953e63a",
    "metadata": {
     "tags": []
    },
@@ -1401,16 +1436,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " AOT_eval/next-item/avg_precision@10 = 0.06432348489761353\n",
-      " AOT_eval/next-item/avg_precision@20 = 0.06879562139511108\n",
-      " AOT_eval/next-item/ndcg@10 = 0.09142451733350754\n",
-      " AOT_eval/next-item/ndcg@20 = 0.10751541703939438\n",
-      " AOT_eval/next-item/recall@10 = 0.17764931917190552\n",
-      " AOT_eval/next-item/recall@20 = 0.24123314023017883\n"
+      " indexed_by_time_eval/next-item/avg_precision@10 = 0.08277411013841629\n",
+      " indexed_by_time_eval/next-item/avg_precision@20 = 0.08782819658517838\n",
+      " indexed_by_time_eval/next-item/ndcg@10 = 0.11141632497310638\n",
+      " indexed_by_time_eval/next-item/ndcg@20 = 0.1303318589925766\n",
+      " indexed_by_time_eval/next-item/recall@10 = 0.20154142379760742\n",
+      " indexed_by_time_eval/next-item/recall@20 = 0.2774566411972046\n"
      ]
     }
    ],
    "source": [
+    "# take the average of metric values over time\n",
     "mean_results = {k: np.mean(v) for k,v in aot_results.items()}\n",
     "for key in sorted(mean_results.keys()): \n",
     "    print(\" %s = %s\" % (key, str(mean_results[key]))) "
@@ -1418,7 +1454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61de28fc",
+   "id": "b171db71",
    "metadata": {},
    "source": [
     "#### Saves the model"
@@ -1427,7 +1463,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "aca62d57",
+   "id": "2e6a43f8",
    "metadata": {
     "tags": []
    },
@@ -1447,7 +1483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "867de4a0",
+   "id": "172611c3",
    "metadata": {},
    "source": [
     "#### Exports the preprocessing workflow and model in the format required by Triton server:** \n",
@@ -1458,7 +1494,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "900d855f",
+   "id": "770e9fe6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1475,7 +1511,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abcbf3c2",
+   "id": "c1ee31bf",
    "metadata": {},
    "source": [
     "## 4. Serving Ensemble Model to the Triton Inference Server"
@@ -1483,7 +1519,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d84718d0",
+   "id": "ea6c8a65",
    "metadata": {},
    "source": [
     "NVIDIA [Triton Inference Server (TIS)](https://github.com/triton-inference-server/server) simplifies the deployment of AI models at scale in production. TIS provides a cloud and edge inferencing solution optimized for both CPUs and GPUs. It supports a number of different machine learning frameworks such as TensorFlow and PyTorch.\n",
@@ -1498,7 +1534,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89ae4876",
+   "id": "65d92df6",
    "metadata": {},
    "source": [
     "### 4.1. Pull and Start Inference Container\n",
@@ -1523,7 +1559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fbd5275",
+   "id": "dfa2c392",
    "metadata": {},
    "source": [
     "### Connect to the Triton Inference Server and check if the server is alive"
@@ -1532,7 +1568,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "38494a8c",
+   "id": "19febb9c",
    "metadata": {
     "tags": []
    },
@@ -1569,7 +1605,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df34e3e3",
+   "id": "26fa0479",
    "metadata": {},
    "source": [
     "### Load raw data for inference\n",
@@ -1579,7 +1615,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "273df114",
+   "id": "ac3f23b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1591,7 +1627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7251a7cf",
+   "id": "b85ac698",
    "metadata": {},
    "source": [
     "### Send the request to triton server"
@@ -1600,7 +1636,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "1a89d90e",
+   "id": "0e49c6b4",
    "metadata": {},
    "outputs": [
     {
@@ -1632,7 +1668,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b779a53b",
+   "id": "0a1e2538",
    "metadata": {},
    "source": [
     "### Load the ensemble model to triton\n",
@@ -1642,7 +1678,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "d3480e0b",
+   "id": "e88b2c30",
    "metadata": {},
    "outputs": [
     {
@@ -1663,7 +1699,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "b3c711da",
+   "id": "85bbb680",
    "metadata": {
     "tags": []
    },
@@ -1710,7 +1746,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ae5632d",
+   "id": "7a1a95b9",
    "metadata": {},
    "source": [
     "- Visualise top-k predictions"
@@ -1719,7 +1755,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "02c0b5e7",
+   "id": "bee19c21",
    "metadata": {
     "tags": []
    },
@@ -1768,7 +1804,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "844c949d",
+   "id": "03edfd95",
    "metadata": {},
    "source": [
     "As you noticed, we first got prediction results (logits) from the trained model head, and then by using a handy util function `visualize_response` we extracted top-k encoded item-ids from logits. Basically, we generated recommended items for a given session.\n",
@@ -1782,7 +1818,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f6274a5",
+   "id": "6a8230f7",
    "metadata": {},
    "source": [
     "**Unload models**"
@@ -1791,7 +1827,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57718050",
+   "id": "b21fde55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1802,7 +1838,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "042f81e3",
+   "id": "07996468",
    "metadata": {},
    "source": [
     "## References"
@@ -1810,7 +1846,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e983a739",
+   "id": "b3c690bb",
    "metadata": {},
    "source": [
     "- Merlin Transformers4rec: https://github.com/NVIDIA-Merlin/Transformers4Rec\n",
@@ -1840,7 +1876,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/examples/end-to-end-session-based/end-to-end-session-based-with-Yoochoose.ipynb
+++ b/examples/end-to-end-session-based/end-to-end-session-based-with-Yoochoose.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "80592ba7",
+   "id": "730944c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ac2bcac",
+   "id": "67d89bcd",
    "metadata": {
     "tags": []
    },
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e4e7e38",
+   "id": "3fdae035",
    "metadata": {},
    "source": [
     "In recent years, several deep learning-based algorithms have been proposed for recommendation systems while its adoption in industry deployments have been steeply growing. In particular, NLP inspired approaches have been successfully adapted for sequential and session-based recommendation problems, which are important for many domains like e-commerce, news and streaming media. Session-Based Recommender Systems (SBRS) have been proposed to model the sequence of interactions within the current user session, where a session is a short sequence of user interactions typically bounded by user inactivity. They have recently gained popularity due to their ability to capture short-term or contextual user preferences towards items. \n",
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd065f3f",
+   "id": "bd5489f6",
    "metadata": {},
    "source": [
     "## 1. Setup"
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2588c0f6",
+   "id": "820f6404",
    "metadata": {},
    "source": [
     "### 1.1. Import Libraries and Define Data Input and Output Paths"
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "20b63545",
+   "id": "224f3bb0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "3012406f",
+   "id": "e7cc2a35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1ddd5c0",
+   "id": "fe5edc4d",
    "metadata": {},
    "source": [
     "### 1.2. Download the data"
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0b665ce",
+   "id": "16b8e561",
    "metadata": {},
    "source": [
     "In this notebook we are using the `YOOCHOOSE` dataset which contains a collection of sessions from a retailer. Each session  encapsulates the click events that the user performed in that session.\n",
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6a9aca7",
+   "id": "4769034c",
    "metadata": {},
    "source": [
     "### 1.3. Load and clean raw data"
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "253d62f1",
+   "id": "bf768d3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77a91ae7",
+   "id": "7c4c9762",
    "metadata": {},
    "source": [
     "#### Remove repeated interactions within the same session"
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "06f85281",
+   "id": "b886a6fb",
    "metadata": {
     "tags": []
    },
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12cbc702",
+   "id": "84512c78",
    "metadata": {},
    "source": [
     "#### Creates new feature with the timestamp when the item was first seen"
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "ad86808e",
+   "id": "ff5afe4a",
    "metadata": {
     "tags": []
    },
@@ -215,43 +215,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>7239</td>\n",
-       "      <td>1396902913</td>\n",
-       "      <td>214640017</td>\n",
+       "      <td>10962</td>\n",
+       "      <td>1396529065</td>\n",
+       "      <td>214716935</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396332599</td>\n",
+       "      <td>1396321225</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>7239</td>\n",
-       "      <td>1396902984</td>\n",
-       "      <td>214827011</td>\n",
+       "      <td>10962</td>\n",
+       "      <td>1396529088</td>\n",
+       "      <td>214716932</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396735848</td>\n",
+       "      <td>1396323181</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>7241</td>\n",
-       "      <td>1396551702</td>\n",
-       "      <td>214820450</td>\n",
+       "      <td>10963</td>\n",
+       "      <td>1396329338</td>\n",
+       "      <td>214833800</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396326153</td>\n",
+       "      <td>1396327488</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>7242</td>\n",
-       "      <td>1396878372</td>\n",
-       "      <td>214552633</td>\n",
+       "      <td>10963</td>\n",
+       "      <td>1396329372</td>\n",
+       "      <td>214832728</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396373414</td>\n",
+       "      <td>1396327694</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>7242</td>\n",
-       "      <td>1396879067</td>\n",
-       "      <td>214839827</td>\n",
+       "      <td>10963</td>\n",
+       "      <td>1396329388</td>\n",
+       "      <td>214833800</td>\n",
        "      <td>0</td>\n",
-       "      <td>1396357542</td>\n",
+       "      <td>1396327488</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -259,11 +259,11 @@
       ],
       "text/plain": [
        "   session_id   timestamp    item_id  category  itemid_ts_first\n",
-       "0        7239  1396902913  214640017         0       1396332599\n",
-       "1        7239  1396902984  214827011         0       1396735848\n",
-       "2        7241  1396551702  214820450         0       1396326153\n",
-       "3        7242  1396878372  214552633         0       1396373414\n",
-       "4        7242  1396879067  214839827         0       1396357542"
+       "0       10962  1396529065  214716935         0       1396321225\n",
+       "1       10962  1396529088  214716932         0       1396323181\n",
+       "2       10963  1396329338  214833800         0       1396327488\n",
+       "3       10963  1396329372  214832728         0       1396327694\n",
+       "4       10963  1396329388  214833800         0       1396327488"
       ]
      },
      "execution_count": 6,
@@ -280,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "57c2cda1",
+   "id": "6d96b068",
    "metadata": {
     "tags": []
    },
@@ -304,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1f1526e",
+   "id": "3a95c064",
    "metadata": {},
    "source": [
     "## 2. Define a preprocessing workflow with NVTabular"
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6aa9514f",
+   "id": "6ee3969b",
    "metadata": {},
    "source": [
     "NVTabular is a feature engineering and preprocessing library for tabular data designed to quickly and easily manipulate terabyte scale datasets used to train deep learning based recommender systems. It provides a high level abstraction to simplify code and accelerates computation on the GPU using the RAPIDS cuDF library.\n",
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea4efdb6",
+   "id": "5b3b9bd0",
    "metadata": {},
    "source": [
     "### 2.1 Feature engineering: Create and Transform items features"
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca96ae08",
+   "id": "838dd8e5",
    "metadata": {},
    "source": [
     "In this cell, we are defining three transformations ops: \n",
@@ -347,7 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "f25800a0",
+   "id": "b6a073a4",
    "metadata": {
     "tags": []
    },
@@ -409,7 +409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e8bc1ae",
+   "id": "0eae8527",
    "metadata": {},
    "source": [
     "### 2.2 Defines the preprocessing of sequential features"
@@ -417,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dd429b2",
+   "id": "c9ade6ef",
    "metadata": {},
    "source": [
     "Once the item features are generated, the objective of this cell is grouping interactions at the session level, sorting the interactions by time. We additionally truncate all sessions to first 20 interactions and filter out sessions with less than 2 interactions."
@@ -426,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "3dfd51bd",
+   "id": "a5db3bcf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "127623cf",
+   "id": "57a7d823",
    "metadata": {},
    "source": [
     "- Avoid Numba low occupancy warnings"
@@ -476,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "eb54a436",
+   "id": "ceb04840",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +486,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c294ae96",
+   "id": "aa09050f",
    "metadata": {},
    "source": [
     "### 2.3 Execute NVTabular workflow"
@@ -494,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2c18671f",
+   "id": "2968c33e",
    "metadata": {},
    "source": [
     "Once we have defined the general workflow (`filtered_sessions`), we provide our cudf dataset to nvt.Dataset class which is optimized to split data into chunks that can fit in device memory and to handle the calculation of complex global statistics. Then, we execute the pipeline that fits and transforms data to get the desired output features."
@@ -503,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "9730c19b",
+   "id": "d4917233",
    "metadata": {
     "tags": []
    },
@@ -519,7 +519,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26c4418c",
+   "id": "71096736",
    "metadata": {},
    "source": [
     "Let's print the head of our preprocessed dataset. You can notice that now each example (row) is a session and the sequential features with respect to user interactions were converted to lists with matching length."
@@ -528,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "f22e5e61",
+   "id": "41bdc644",
    "metadata": {
     "tags": []
    },
@@ -666,7 +666,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe280635",
+   "id": "02ff1f8b",
    "metadata": {},
    "source": [
     "#### Saves the preprocessing workflow"
@@ -675,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "faa4a886",
+   "id": "70e6e2a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,7 +684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3be0df8",
+   "id": "f6b88c0e",
    "metadata": {},
    "source": [
     "### 2.4 Export pre-processed data by day"
@@ -692,7 +692,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf8cc025",
+   "id": "5899dfb2",
    "metadata": {},
    "source": [
     "In this example we are going to split the preprocessed parquet files by days, to allow for temporal training and evaluation. There will be a folder for each day and three parquet files within each day: `train.parquet`, `validation.parquet` and `test.parquet`\n",
@@ -703,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "43c69589",
+   "id": "492cffde",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -713,7 +713,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "75ce8ba4",
+   "id": "3f1af129",
    "metadata": {
     "tags": []
    },
@@ -722,7 +722,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Creating time-based splits: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00,  8.28it/s]\n"
+      "Creating time-based splits: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00,  8.39it/s]\n"
      ]
     }
    ],
@@ -738,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "419d60de",
+   "id": "5e969f31",
    "metadata": {
     "tags": []
    },
@@ -779,7 +779,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "8e3f0f05",
+   "id": "4d733137",
    "metadata": {
     "tags": []
    },
@@ -803,7 +803,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "853d9f9c",
+   "id": "62f2ab0d",
    "metadata": {},
    "source": [
     "## 3. Model definition using Transformers4Rec"
@@ -811,7 +811,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "646422f1",
+   "id": "293202f2",
    "metadata": {},
    "source": [
     "### 3.1 Get the schema "
@@ -819,7 +819,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96d9a87e",
+   "id": "6c7a404a",
    "metadata": {},
    "source": [
     "The library uses a schema format to configure the input features and automatically creates the necessary layers. This *protobuf* text file contains the description of each input feature by defining: the name, the type, the number of elements of a list column,  the cardinality of a categorical feature and the min and max values of each feature. In addition, the annotation field contains the tags such as specifying `continuous` and `categorical` features, the `target` column or the `item_id` feature, among others."
@@ -828,7 +828,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "277a5969",
+   "id": "dd80d176",
    "metadata": {
     "tags": []
    },
@@ -936,7 +936,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "185452cb",
+   "id": "b7f65daa",
    "metadata": {},
    "source": [
     "We can select the subset of features we want to use for training the model by their tags or their names."
@@ -945,7 +945,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "60698c61",
+   "id": "07389ed5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,7 +956,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3f049c7",
+   "id": "f3d2bc06",
    "metadata": {},
    "source": [
     "### 3.2 Define the end-to-end Session-based Transformer-based recommendation model"
@@ -964,7 +964,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6411cfa",
+   "id": "26fd854a",
    "metadata": {
     "tags": []
    },
@@ -985,7 +985,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "527c7389",
+   "id": "3a1fb52a",
    "metadata": {
     "tags": []
    },
@@ -1027,7 +1027,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "63472254",
+   "id": "3b67b87a",
    "metadata": {
     "tags": []
    },
@@ -1160,7 +1160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "707bcb90",
+   "id": "0ae46670",
    "metadata": {},
    "source": [
     "### 3.3. Daily Fine-Tuning: Training over a time window¶"
@@ -1168,7 +1168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c669fd97",
+   "id": "3a355e98",
    "metadata": {},
    "source": [
     "Now that the model is defined, we are going to launch training. For that, Transfromers4rec extends HF Transformers Trainer class to adapt the evaluation loop for session-based recommendation task and the calculation of ranking metrics. The original `train()` method is not modified meaning that we leverage the efficient training implementation from that library, which manages for example half-precision (FP16) training."
@@ -1176,7 +1176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f845f95",
+   "id": "7368c5fb",
    "metadata": {},
    "source": [
     "#### Sets Training arguments"
@@ -1184,7 +1184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eac11371",
+   "id": "06449c0f",
    "metadata": {},
    "source": [
     "An additional argument `data_loader_engine` is defined to automatically load the features needed for training using the schema. The default value is `nvtabular` for optimized GPU-based data-loading.  Optionally a `PyarrowDataLoader` (`pyarrow`) can also be used as a basic option, but it is slower and works only for small datasets, as the full data is loaded to CPU memory."
@@ -1193,7 +1193,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "cc635ebd",
+   "id": "f18e2a3b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1214,7 +1214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a2a6d41",
+   "id": "dbf5bdfa",
    "metadata": {},
    "source": [
     "#### Instantiate the trainer"
@@ -1223,7 +1223,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "3bf1e68e",
+   "id": "63dc212c",
    "metadata": {
     "tags": []
    },
@@ -1246,7 +1246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0faecc0",
+   "id": "bb57126e",
    "metadata": {},
    "source": [
     "#### Launches daily Training and Evaluation"
@@ -1254,16 +1254,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce43d452",
+   "id": "766eba12",
    "metadata": {},
    "source": [
-    "In this demo, we will use the `fit_and_evaluate` method that allows us to conduct a time-based finetuning by iteratively training and evaluating using a sliding time window: At each iteration, we use training data of a specific time index $t$ to train the model then we evaluate on the validation data of next index $t + 1$. Particularly, both the start and end time is set to 178."
+    "In this demo, we will use the `fit_and_evaluate` method that allows us to conduct a time-based finetuning by iteratively training and evaluating using a sliding time window: At each iteration, we use training data of a specific time index $t$ to train the model then we evaluate on the validation data of next index $t + 1$. Particularly, we set start time to 178 and end time to 180."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "c8018840",
+   "id": "b7bea2f8",
    "metadata": {
     "tags": []
    },
@@ -1308,15 +1308,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <td>200</td>\n",
-       "      <td>7.710400</td>\n",
+       "      <td>7.721300</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>400</td>\n",
-       "      <td>6.630000</td>\n",
+       "      <td>6.645300</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>600</td>\n",
-       "      <td>6.327400</td>\n",
+       "      <td>6.346600</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table><p>"
@@ -1347,8 +1347,8 @@
        "\n",
        "    <div>\n",
        "      \n",
-       "      <progress value='6' max='6' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      [6/6 00:00]\n",
+       "      <progress value='14' max='6' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [6/6 00:38]\n",
        "    </div>\n",
        "    "
       ],
@@ -1366,23 +1366,171 @@
       "\n",
       "***** Evaluation results for day 179:*****\n",
       "\n",
-      " eval/next-item/avg_precision@10 = 0.08277411013841629\n",
-      " eval/next-item/avg_precision@20 = 0.08782819658517838\n",
-      " eval/next-item/ndcg@10 = 0.11141632497310638\n",
-      " eval/next-item/ndcg@20 = 0.1303318589925766\n",
-      " eval/next-item/recall@10 = 0.20154142379760742\n",
-      " eval/next-item/recall@20 = 0.2774566411972046\n"
+      " eval/next-item/avg_precision@10 = 0.08169878274202347\n",
+      " eval/next-item/avg_precision@20 = 0.08574782311916351\n",
+      " eval/next-item/ndcg@10 = 0.11046259850263596\n",
+      " eval/next-item/ndcg@20 = 0.12532013654708862\n",
+      " eval/next-item/recall@10 = 0.20192678272724152\n",
+      " eval/next-item/recall@20 = 0.2608863115310669\n",
+      "\n",
+      "***** Launch training for day 179: *****\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "***** Running training *****\n",
+      "  Num examples = 20736\n",
+      "  Num Epochs = 10\n",
+      "  Instantaneous batch size per device = 384\n",
+      "  Total train batch size (w. parallel, distributed & accumulation) = 384\n",
+      "  Gradient Accumulation steps = 1\n",
+      "  Total optimization steps = 540\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='540' max='540' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [540/540 00:20, Epoch 10/10]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>Step</th>\n",
+       "      <th>Training Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>200</td>\n",
+       "      <td>6.845400</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>400</td>\n",
+       "      <td>6.425500</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Saving model checkpoint to ./tmp/checkpoint-500\n",
+      "Trainer.model is not a `PreTrainedModel`, only saving its state dict.\n",
+      "\n",
+      "\n",
+      "Training completed. Do not forget to share your model on huggingface.co/models =)\n",
+      "\n",
+      "\n",
+      "***** Running training *****\n",
+      "  Num examples = 16896\n",
+      "  Num Epochs = 10\n",
+      "  Instantaneous batch size per device = 384\n",
+      "  Total train batch size (w. parallel, distributed & accumulation) = 384\n",
+      "  Gradient Accumulation steps = 1\n",
+      "  Total optimization steps = 440\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "***** Evaluation results for day 180:*****\n",
+      "\n",
+      " eval/next-item/avg_precision@10 = 0.06733544170856476\n",
+      " eval/next-item/avg_precision@20 = 0.07138364017009735\n",
+      " eval/next-item/ndcg@10 = 0.09150198847055435\n",
+      " eval/next-item/ndcg@20 = 0.10659514367580414\n",
+      " eval/next-item/recall@10 = 0.16969697177410126\n",
+      " eval/next-item/recall@20 = 0.2293706238269806\n",
+      "\n",
+      "***** Launch training for day 180: *****\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "      \n",
+       "      <progress value='440' max='440' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      [440/440 00:17, Epoch 10/10]\n",
+       "    </div>\n",
+       "    <table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: left;\">\n",
+       "      <th>Step</th>\n",
+       "      <th>Training Loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>200</td>\n",
+       "      <td>6.880100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>400</td>\n",
+       "      <td>6.469300</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table><p>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Training completed. Do not forget to share your model on huggingface.co/models =)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "***** Evaluation results for day 181:*****\n",
+      "\n",
+      " eval/next-item/avg_precision@10 = 0.12588053941726685\n",
+      " eval/next-item/avg_precision@20 = 0.13366079330444336\n",
+      " eval/next-item/ndcg@10 = 0.17167863249778748\n",
+      " eval/next-item/ndcg@20 = 0.200278639793396\n",
+      " eval/next-item/recall@10 = 0.3200370967388153\n",
+      " eval/next-item/recall@20 = 0.4313543736934662\n"
      ]
     }
    ],
    "source": [
     "from transformers4rec.torch.utils.examples_utils import fit_and_evaluate\n",
-    "aot_results = fit_and_evaluate(recsys_trainer, start_time_index=178, end_time_index=178, input_dir='./preproc_sessions_by_day')"
+    "OT_results = fit_and_evaluate(recsys_trainer, start_time_index=178, end_time_index=180, input_dir='./preproc_sessions_by_day')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "31e6cf87",
+   "id": "24960448",
    "metadata": {
     "tags": []
    },
@@ -1392,42 +1540,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a726ee60",
+   "id": "7c430b21",
    "metadata": {},
    "source": [
-    "`aot_results` is a list of scores (accuracy metrics) for evaluation based on given start and end time_index. Since in this example we do evaluation only on day 179, we only get one metric in the list."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "2ed03be9",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'indexed_by_time_eval/next-item/avg_precision@10': [0.08277411013841629],\n",
-       " 'indexed_by_time_eval/next-item/avg_precision@20': [0.08782819658517838],\n",
-       " 'indexed_by_time_eval/next-item/ndcg@10': [0.11141632497310638],\n",
-       " 'indexed_by_time_eval/next-item/ndcg@20': [0.1303318589925766],\n",
-       " 'indexed_by_time_eval/next-item/recall@10': [0.20154142379760742],\n",
-       " 'indexed_by_time_eval/next-item/recall@20': [0.2774566411972046]}"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "aot_results"
+    "`OT_results` is a list of scores (accuracy metrics) for evaluation based on given start and end time_index. Since in this example we do evaluation on days 179, 180 and 181, we get three metrics in the list one for each day."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "7953e63a",
+   "id": "cf9e4e96",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'indexed_by_time_eval/next-item/avg_precision@10': [0.08169878274202347,\n",
+       "  0.06733544170856476,\n",
+       "  0.12588053941726685],\n",
+       " 'indexed_by_time_eval/next-item/avg_precision@20': [0.08574782311916351,\n",
+       "  0.07138364017009735,\n",
+       "  0.13366079330444336],\n",
+       " 'indexed_by_time_eval/next-item/ndcg@10': [0.11046259850263596,\n",
+       "  0.09150198847055435,\n",
+       "  0.17167863249778748],\n",
+       " 'indexed_by_time_eval/next-item/ndcg@20': [0.12532013654708862,\n",
+       "  0.10659514367580414,\n",
+       "  0.200278639793396],\n",
+       " 'indexed_by_time_eval/next-item/recall@10': [0.20192678272724152,\n",
+       "  0.16969697177410126,\n",
+       "  0.3200370967388153],\n",
+       " 'indexed_by_time_eval/next-item/recall@20': [0.2608863115310669,\n",
+       "  0.2293706238269806,\n",
+       "  0.4313543736934662]}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "OT_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "9778f80a",
    "metadata": {
     "tags": []
    },
@@ -1436,25 +1596,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " indexed_by_time_eval/next-item/avg_precision@10 = 0.08277411013841629\n",
-      " indexed_by_time_eval/next-item/avg_precision@20 = 0.08782819658517838\n",
-      " indexed_by_time_eval/next-item/ndcg@10 = 0.11141632497310638\n",
-      " indexed_by_time_eval/next-item/ndcg@20 = 0.1303318589925766\n",
-      " indexed_by_time_eval/next-item/recall@10 = 0.20154142379760742\n",
-      " indexed_by_time_eval/next-item/recall@20 = 0.2774566411972046\n"
+      " indexed_by_time_eval/next-item/avg_precision@10 = 0.09163825462261836\n",
+      " indexed_by_time_eval/next-item/avg_precision@20 = 0.09693075219790141\n",
+      " indexed_by_time_eval/next-item/ndcg@10 = 0.12454773982365926\n",
+      " indexed_by_time_eval/next-item/ndcg@20 = 0.1440646400054296\n",
+      " indexed_by_time_eval/next-item/recall@10 = 0.2305536170800527\n",
+      " indexed_by_time_eval/next-item/recall@20 = 0.3072037696838379\n"
      ]
     }
    ],
    "source": [
     "# take the average of metric values over time\n",
-    "mean_results = {k: np.mean(v) for k,v in aot_results.items()}\n",
-    "for key in sorted(mean_results.keys()): \n",
-    "    print(\" %s = %s\" % (key, str(mean_results[key]))) "
+    "avg_results = {k: np.mean(v) for k,v in OT_results.items()}\n",
+    "for key in sorted(avg_results.keys()): \n",
+    "    print(\" %s = %s\" % (key, str(avg_results[key]))) "
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b171db71",
+   "id": "41a2c427",
    "metadata": {},
    "source": [
     "#### Saves the model"
@@ -1463,7 +1623,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "2e6a43f8",
+   "id": "0c0fc9f9",
    "metadata": {
     "tags": []
    },
@@ -1483,7 +1643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "172611c3",
+   "id": "5e475669",
    "metadata": {},
    "source": [
     "#### Exports the preprocessing workflow and model in the format required by Triton server:** \n",
@@ -1494,7 +1654,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "770e9fe6",
+   "id": "6b478fef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1511,7 +1671,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1ee31bf",
+   "id": "75e4d037",
    "metadata": {},
    "source": [
     "## 4. Serving Ensemble Model to the Triton Inference Server"
@@ -1519,7 +1679,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea6c8a65",
+   "id": "89a57bcf",
    "metadata": {},
    "source": [
     "NVIDIA [Triton Inference Server (TIS)](https://github.com/triton-inference-server/server) simplifies the deployment of AI models at scale in production. TIS provides a cloud and edge inferencing solution optimized for both CPUs and GPUs. It supports a number of different machine learning frameworks such as TensorFlow and PyTorch.\n",
@@ -1534,7 +1694,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65d92df6",
+   "id": "5acf88cf",
    "metadata": {},
    "source": [
     "### 4.1. Pull and Start Inference Container\n",
@@ -1559,7 +1719,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfa2c392",
+   "id": "954cf6d3",
    "metadata": {},
    "source": [
     "### Connect to the Triton Inference Server and check if the server is alive"
@@ -1568,7 +1728,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "19febb9c",
+   "id": "1d3b5885",
    "metadata": {
     "tags": []
    },
@@ -1605,7 +1765,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26fa0479",
+   "id": "32458160",
    "metadata": {},
    "source": [
     "### Load raw data for inference\n",
@@ -1615,7 +1775,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "ac3f23b2",
+   "id": "511c4032",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1627,7 +1787,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b85ac698",
+   "id": "67452782",
    "metadata": {},
    "source": [
     "### Send the request to triton server"
@@ -1636,7 +1796,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "0e49c6b4",
+   "id": "bc285a81",
    "metadata": {},
    "outputs": [
     {
@@ -1668,7 +1828,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a1e2538",
+   "id": "3b3a9b6d",
    "metadata": {},
    "source": [
     "### Load the ensemble model to triton\n",
@@ -1678,7 +1838,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "e88b2c30",
+   "id": "1d64f351",
    "metadata": {},
    "outputs": [
     {
@@ -1699,7 +1859,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "85bbb680",
+   "id": "92d6d20a",
    "metadata": {
     "tags": []
    },
@@ -1746,7 +1906,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a1a95b9",
+   "id": "b2509ebd",
    "metadata": {},
    "source": [
     "- Visualise top-k predictions"
@@ -1755,7 +1915,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "bee19c21",
+   "id": "27c78a6c",
    "metadata": {
     "tags": []
    },
@@ -1804,7 +1964,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03edfd95",
+   "id": "a4ac318f",
    "metadata": {},
    "source": [
     "As you noticed, we first got prediction results (logits) from the trained model head, and then by using a handy util function `visualize_response` we extracted top-k encoded item-ids from logits. Basically, we generated recommended items for a given session.\n",
@@ -1818,7 +1978,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a8230f7",
+   "id": "8faccae6",
    "metadata": {},
    "source": [
     "**Unload models**"
@@ -1827,7 +1987,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b21fde55",
+   "id": "add4ba68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1838,7 +1998,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07996468",
+   "id": "826e47de",
    "metadata": {},
    "source": [
     "## References"
@@ -1846,7 +2006,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3c690bb",
+   "id": "c3f26f40",
    "metadata": {},
    "source": [
     "- Merlin Transformers4rec: https://github.com/NVIDIA-Merlin/Transformers4Rec\n",

--- a/transformers4rec/torch/utils/examples_utils.py
+++ b/transformers4rec/torch/utils/examples_utils.py
@@ -59,10 +59,10 @@ def fit_and_evaluate(trainer, start_time_index, end_time_index, input_dir):
 
     Returns
     -------
-    aot_metrics: dict
-        The average over time of ranking metrics.
+    indexed_by_time_metrics: dict
+        The dictionary of ranking metrics: each item is the list of scores over time indices.
     """
-    aot_metrics = {}
+    indexed_by_time_metrics = {}
     for time_index in range(start_time_index, end_time_index + 1):
         # 1. Set data
         time_index_train = time_index
@@ -82,16 +82,20 @@ def fit_and_evaluate(trainer, start_time_index, end_time_index, input_dir):
         print("\n***** Evaluation results for day %s:*****\n" % time_index_eval)
         for key in sorted(eval_metrics.keys()):
             if "at_" in key:
-                print(" %s = %s" % (key.replace("at_", "@"), str(eval_metrics[key])))
-                if "AOT_" + key.replace("at_", "@") in aot_metrics:
-                    aot_metrics["AOT_" + key.replace("_at_", "@")] += [eval_metrics[key]]
+                print(" %s = %s" % (key.replace("_at_", "@"), str(eval_metrics[key])))
+                if "indexed_by_time_" + key.replace("_at_", "@") in indexed_by_time_metrics:
+                    indexed_by_time_metrics["indexed_by_time_" + key.replace("_at_", "@")] += [
+                        eval_metrics[key]
+                    ]
                 else:
-                    aot_metrics["AOT_" + key.replace("_at_", "@")] = [eval_metrics[key]]
+                    indexed_by_time_metrics["indexed_by_time_" + key.replace("_at_", "@")] = [
+                        eval_metrics[key]
+                    ]
 
         # free GPU for next day training
         wipe_memory()
 
-    return aot_metrics
+    return indexed_by_time_metrics
 
 
 def wipe_memory():


### PR DESCRIPTION
- @rnyak reported a bug related to `fit_and_evaluate` method always returning a list with one score,  the score of last time index. This is caused by a missing `_` when checking the metric key name. 

- The expected behavior is to get the list of scores related to all-time indices. 

- This PR fixes the issue and updates doc-strings for more clarity about what is returned by the function.  

