### PR TITLE
Add MRR to ranking metrics module

### DIFF
--- a/tests/torch/test_ranking_metrics.py
+++ b/tests/torch/test_ranking_metrics.py
@@ -17,7 +17,6 @@
 import pytest
 import torch
 
-# from transformers4rec.torch.ranking_metric import MeanRecipricolRankAt
 from transformers4rec.torch.ranking_metric import MeanRecipricolRankAt
 
 tr = pytest.importorskip("transformers4rec.torch")

--- a/tests/torch/test_ranking_metrics.py
+++ b/tests/torch/test_ranking_metrics.py
@@ -50,14 +50,19 @@ def test_mean_recipricol_rank():
     metric = MeanRecipricolRankAt()
     metric.top_ks = [1, 2, 3, 4]
     metric.labels_onehot = False
-    result = metric(torch.tensor([[1, 2, 3, 4, 5, 4, 3, 2, 1],
-                                  [1, 2, 3, 4, 5, 4, 3, 2, 1],
-                                  [1, 2, 3, 4, 5, 4, 3, 2, 1]]),
-                    torch.tensor([[0, 0, 0, 0, 0, 0, 0, 1, 0],
-                                  [0, 0, 0, 0, 0, 1, 0, 0, 0],
-                                  [0, 0, 0, 0, 1, 0, 0, 0, 0]]))
-    assert torch.all(torch.lt(torch.abs(torch.add(result,
-                                                  -torch.tensor([0.3333, 0.3333, 0.4444, 0.4444]))), 1e-3))
+    result = metric(
+        torch.tensor(
+            [[1, 2, 3, 4, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 4, 3, 2, 1]]
+        ),
+        torch.tensor(
+            [[0, 0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 1, 0, 0, 0], [0, 0, 0, 0, 1, 0, 0, 0, 0]]
+        ),
+    )
+    assert torch.all(
+        torch.lt(
+            torch.abs(torch.add(result, -torch.tensor([0.3333, 0.3333, 0.4444, 0.4444]))), 1e-3
+        )
+    )
 
 
 # TODO: Compare the metrics @K between pytorch and numpy

--- a/tests/torch/test_ranking_metrics.py
+++ b/tests/torch/test_ranking_metrics.py
@@ -15,6 +15,10 @@
 #
 
 import pytest
+import torch
+
+# from transformers4rec.torch.ranking_metric import MeanRecipricolRankAt
+from transformers4rec.torch.ranking_metric import MeanRecipricolRankAt
 
 tr = pytest.importorskip("transformers4rec.torch")
 
@@ -41,6 +45,20 @@ def test_score_with_transform_onehot(torch_ranking_metrics_inputs, metric):
     metric.labels_onehot = True
     result = metric(torch_ranking_metrics_inputs["scores"], torch_ranking_metrics_inputs["labels"])
     assert len(result) == len(torch_ranking_metrics_inputs["ks"])
+
+
+def test_mean_recipricol_rank():
+    metric = MeanRecipricolRankAt()
+    metric.top_ks = [1, 2, 3, 4]
+    metric.labels_onehot = False
+    result = metric(torch.tensor([[1, 2, 3, 4, 5, 4, 3, 2, 1],
+                                  [1, 2, 3, 4, 5, 4, 3, 2, 1],
+                                  [1, 2, 3, 4, 5, 4, 3, 2, 1]]),
+                    torch.tensor([[0, 0, 0, 0, 0, 0, 0, 1, 0],
+                                  [0, 0, 0, 0, 0, 1, 0, 0, 0],
+                                  [0, 0, 0, 0, 1, 0, 0, 0, 0]]))
+    assert torch.all(torch.lt(torch.abs(torch.add(result,
+                                                  -torch.tensor([0.3333, 0.3333, 0.4444, 0.4444]))), 1e-3))
 
 
 # TODO: Compare the metrics @K between pytorch and numpy

--- a/transformers4rec/torch/ranking_metric.py
+++ b/transformers4rec/torch/ranking_metric.py
@@ -276,3 +276,38 @@ class NDCGAt(RankingMetric):
         gains[relevant_pos] /= normalizing_gains[relevant_pos]
 
         return gains
+
+
+@ranking_metrics_registry.register_with_multiple_names("mrr_at", "mrr")
+class MeanRecipricolRankAt(RankingMetric):
+    def __init__(self, top_ks=None, labels_onehot=False):
+        super(MeanRecipricolRankAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
+
+    def _metric(
+            self, ks: torch.Tensor, scores: torch.Tensor, labels: torch.Tensor, log_base: int = 2
+    ) -> torch.Tensor:
+        """Compute mean recipricol rank at K for provided cutoffs (ignoring ties)
+
+        Parameters
+        ----------
+        ks : torch.Tensor or list
+            list of cutoffs
+        scores : torch.Tensor
+            predicted item scores
+        labels : torch.Tensor
+            true item labels
+
+        Returns
+        -------
+        torch.Tensor :
+            list of mean recipricol rank at cutoffs
+        """
+        ks, scores, labels = torch_utils.check_inputs(ks, scores, labels)
+        topk_scores, topk_indices, topk_labels = torch_utils.extract_topk(ks, scores, labels)
+
+        results = torch.zeros(scores.shape[0], len(ks)) \
+            .to(device=scores.device, dtype=torch.float32)
+        for index, k in enumerate(ks):
+            values, _ = (topk_labels[:, :k] / (torch.arange(k) + 1)).max(dim=1)
+            results[:, index] = values
+        return results

--- a/transformers4rec/torch/ranking_metric.py
+++ b/transformers4rec/torch/ranking_metric.py
@@ -284,7 +284,7 @@ class MeanRecipricolRankAt(RankingMetric):
         super(MeanRecipricolRankAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
 
     def _metric(
-            self, ks: torch.Tensor, scores: torch.Tensor, labels: torch.Tensor, log_base: int = 2
+        self, ks: torch.Tensor, scores: torch.Tensor, labels: torch.Tensor, log_base: int = 2
     ) -> torch.Tensor:
         """Compute mean recipricol rank at K for provided cutoffs (ignoring ties)
 
@@ -305,8 +305,9 @@ class MeanRecipricolRankAt(RankingMetric):
         ks, scores, labels = torch_utils.check_inputs(ks, scores, labels)
         topk_scores, topk_indices, topk_labels = torch_utils.extract_topk(ks, scores, labels)
 
-        results = torch.zeros(scores.shape[0], len(ks)) \
-            .to(device=scores.device, dtype=torch.float32)
+        results = torch.zeros(scores.shape[0], len(ks)).to(
+            device=scores.device, dtype=torch.float32
+        )
         for index, k in enumerate(ks):
             values, _ = (topk_labels[:, :k] / (torch.arange(k) + 1)).max(dim=1)
             results[:, index] = values


### PR DESCRIPTION
Fixes https://github.com/NVIDIA-Merlin/Transformers4Rec/issues/86

### Goals :soccer:
Add support for mean reciprocal rank

### Implementation Details :construction:
I followed the template of NDCG to implement this. 

### Testing Details :mag:
Single basic unit test.
