### PR TITLE
Remove pinned keras version

### DIFF
--- a/requirements/tensorflow.txt
+++ b/requirements/tensorflow.txt
@@ -1,2 +1,1 @@
 tensorflow>=2.3
-keras==2.6.*


### PR DESCRIPTION
During CI we are downloading multiple versions of TF and inspecting each one
trying to resolve dependencies. This seems to be because we are
specifying an exact version of keras, but a range of possible TF versions.

Remove the pin, since it was put in place as a temporary workaround until
TF 2.7 was released in https://github.com/NVIDIA-Merlin/Transformers4Rec/pull/312.