### PR TITLE
Improve TOC navigation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,7 @@ exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 #
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {
-    "navigation_depth": 2,
+    "titles_only": True,
 }
 html_show_sourcelink = False
 


### PR DESCRIPTION
Previously, the navigation was set to a specific level with
the result that some pages offered too many headings and
other pages were orphaned--no way to browse to the page other
than clicking a link on an HTML page.

With the change, only the H1 for each page is shown. This provides
a good balance--all pages can be browsed from the TOC and pages
with several H2 and H3s do not cause the TOC to be "jumpy."