### PR TITLE
support sequential binary task

### DIFF
--- a/tests/torch/model/test_head.py
+++ b/tests/torch/model/test_head.py
@@ -41,12 +41,15 @@ def test_simple_heads(torch_tabular_features, torch_tabular_data, task):
 
 @pytest.mark.parametrize("task", [tr.BinaryClassificationTask, tr.RegressionTask])
 @pytest.mark.parametrize("task_block", [None, tr.MLPBlock([32]), tr.MLPBlock([32]).build([-1, 64])])
-@pytest.mark.parametrize("summary", ["last", "first", "mean", "cls_index"])
+@pytest.mark.parametrize("summary", [None, "last", "first", "mean", "cls_index"])
 def test_simple_heads_on_sequence(
     torch_yoochoose_tabular_transformer_features, torch_yoochoose_like, task, task_block, summary
 ):
     inputs = torch_yoochoose_tabular_transformer_features
-    targets = {"target": pytorch.randint(2, (100,)).float()}
+    if summary:
+        targets = {"target": pytorch.randint(2, (100,)).float()}
+    else:
+        targets = {"target": pytorch.randint(2, (2000,)).float()}
 
     body = tr.SequentialBlock(inputs, tr.MLPBlock([64]))
     head = task("target", task_block=task_block, summary_type=summary).to_head(body, inputs)

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -80,8 +80,9 @@ class PredictionTask(torch.nn.Module, LossMixin, MetricsMixin):
         summary_type: str = "last",
     ):
         super().__init__()
+        self.summary_type = summary_type
         self.sequence_summary = SequenceSummary(
-            SimpleNamespace(summary_type=summary_type)  # type: ignore
+            SimpleNamespace(summary_type=self.summary_type)  # type: ignore
         )  # noqa
         self.target_name = target_name
         self.forward_to_prediction_fn = forward_to_prediction_fn
@@ -143,7 +144,7 @@ class PredictionTask(torch.nn.Module, LossMixin, MetricsMixin):
     def forward(self, inputs, **kwargs):
         x = inputs
 
-        if len(x.size()) == 3:
+        if len(x.size()) == 3 and self.summary_type:
             x = self.sequence_summary(x)
 
         if self.task_block:


### PR DESCRIPTION

Fixes #265

### Goals :soccer:
This PR extends BinaryClassificationTask and RegressionTask to support interaction-level predictions. In this new setting, the model returns a prediction score for each interaction in the sequence. 
@gabrielspmoreira, do you think we should also support partial prediction where only subsets of positions are predicted? (something like a masked binary task?) 

### Implementation Details :construction:
Currently, the PredictionTask is by default converting a 3-d sequence representation to a 2-d based on the specified `summary_type` argument. This PR includes the case `summary_type=None` where the 3-d sequence is kept. 

### Testing Details :mag:
Update the unit test `test_simple_heads_on_sequence` with the new case of `summary_type=None`
