### PR TITLE
Set `INPUT_DATA_DIR` env var to `/tmp/data` in notebook tests

### DIFF
--- a/tests/unit/test_notebooks.py
+++ b/tests/unit/test_notebooks.py
@@ -31,6 +31,7 @@ SESSION_PATH = "examples/getting-started-session-based/"
 @pytest.mark.skipif(importlib.util.find_spec("cudf") is None, reason="needs cudf")
 def test_session(tmpdir):
     BASE_PATH = os.path.join(dirname(TEST_PATH), SESSION_PATH)
+    os.environ["INPUT_DATA_DIR"] = "/tmp/data/"
     # Run ETL
     nb_path = os.path.join(BASE_PATH, "01-ETL-with-NVTabular.ipynb")
     _run_notebook(tmpdir, nb_path)


### PR DESCRIPTION
Otherwise, the notebook tests fail in Jenkins, where the `jenkins` user doesn't have access to `/workspace/data`.

<!--

Thank you for contributing to Transformers4Rec :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes # (issue)

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
