### PR TITLE
Update requirement on `nvidia-dllogger` to follow install instructions

### DIFF
--- a/examples/t4rec_paper_experiments/requirements.txt
+++ b/examples/t4rec_paper_experiments/requirements.txt
@@ -1,4 +1,4 @@
 wandb
 pandas
 nvidia-pyindex
-nvidia-dllogger
+git+https://github.com/NVIDIA/dllogger#egg=dllogger


### PR DESCRIPTION
This package isn't available from PyPI, which seems to be where our integration tests are looking for it. The README [suggests installing it](https://github.com/NVIDIA/dllogger#installation) this way. 