### PR TITLE
Change the metric names prefix to align with the HF trainer code.

### DIFF
--- a/tests/torch/test_trainer.py
+++ b/tests/torch/test_trainer.py
@@ -176,15 +176,15 @@ def test_trainer_eval_loop(torch_yoochoose_next_item_prediction_model):
 
     assert isinstance(eval_metrics, dict)
     default_metric = [
-        "eval/next-item/ndcg_at_10",
-        "eval/next-item/ndcg_at_20",
-        "eval/next-item/avg_precision_at_10",
-        "eval/next-item/avg_precision_at_20",
-        "eval/next-item/recall_at_10",
-        "eval/next-item/recall_at_20",
+        "eval_next-item/ndcg_at_10",
+        "eval_next-item/ndcg_at_20",
+        "eval_next-item/avg_precision_at_10",
+        "eval_next-item/avg_precision_at_20",
+        "eval_next-item/recall_at_10",
+        "eval_next-item/recall_at_20",
     ]
     assert set(default_metric).issubset(set(eval_metrics.keys()))
-    assert eval_metrics["eval/loss"] is not None
+    assert eval_metrics["eval_loss"] is not None
 
     assert predictions is not None
 
@@ -263,11 +263,11 @@ def test_evaluate_results(torch_yoochoose_next_item_prediction_model):
         compute_metrics=True,
     )
     default_metric = [
-        "eval/next-item/ndcg_at_10",
-        "eval/next-item/ndcg_at_20",
-        "eval/next-item/recall_at_10",
-        "eval/next-item/recall_at_20",
-        "eval/loss",
+        "eval_next-item/ndcg_at_10",
+        "eval_next-item/ndcg_at_20",
+        "eval_next-item/recall_at_10",
+        "eval_next-item/recall_at_20",
+        "eval_loss",
     ]
 
     result_1 = recsys_trainer.evaluate(eval_dataset=data.path, metric_key_prefix="eval")

--- a/tests/torch/test_trainer.py
+++ b/tests/torch/test_trainer.py
@@ -176,15 +176,15 @@ def test_trainer_eval_loop(torch_yoochoose_next_item_prediction_model):
 
     assert isinstance(eval_metrics, dict)
     default_metric = [
-        "eval_next-item/ndcg_at_10",
-        "eval_next-item/ndcg_at_20",
-        "eval_next-item/avg_precision_at_10",
-        "eval_next-item/avg_precision_at_20",
-        "eval_next-item/recall_at_10",
-        "eval_next-item/recall_at_20",
+        "eval_/next-item/ndcg_at_10",
+        "eval_/next-item/ndcg_at_20",
+        "eval_/next-item/avg_precision_at_10",
+        "eval_/next-item/avg_precision_at_20",
+        "eval_/next-item/recall_at_10",
+        "eval_/next-item/recall_at_20",
     ]
     assert set(default_metric).issubset(set(eval_metrics.keys()))
-    assert eval_metrics["eval_loss"] is not None
+    assert eval_metrics["eval_/loss"] is not None
 
     assert predictions is not None
 
@@ -236,6 +236,43 @@ def test_saves_checkpoints(torch_yoochoose_next_item_prediction_model):
             assert os.path.isfile(os.path.join(checkpoint, filename))
 
 
+def test_saves_checkpoints_best_metric(torch_yoochoose_next_item_prediction_model):
+    pytest.importorskip("pyarrow")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        batch_size = 16
+        args = trainer.T4RecTrainingArguments(
+            output_dir=tmpdir,
+            num_train_epochs=3,
+            per_device_train_batch_size=batch_size,
+            per_device_eval_batch_size=batch_size // 2,
+            data_loader_engine="pyarrow",
+            max_sequence_length=20,
+            fp16=False,
+            no_cuda=True,
+            report_to=[],
+            debug=["r"],
+            save_total_limit=2,
+            save_steps=100,
+            eval_steps=100,
+            evaluation_strategy="steps",
+            save_strategy="steps",
+            load_best_model_at_end=True,
+            metric_for_best_model="/next-item/recall_at_10",
+        )
+        data = tr.data.tabular_sequence_testing_data
+        recsys_trainer = tr.Trainer(
+            model=torch_yoochoose_next_item_prediction_model,
+            args=args,
+            schema=data.schema,
+            train_dataset_or_path=data.path,
+            eval_dataset_or_path=data.path,
+            compute_metrics=True,
+        )
+        recsys_trainer.train()
+        assert len(os.listdir(tmpdir)) == 1
+        assert "checkpoint-100" in os.listdir(tmpdir)
+
+
 def test_evaluate_results(torch_yoochoose_next_item_prediction_model):
     pytest.importorskip("pyarrow")
     batch_size = 16
@@ -263,11 +300,11 @@ def test_evaluate_results(torch_yoochoose_next_item_prediction_model):
         compute_metrics=True,
     )
     default_metric = [
-        "eval_next-item/ndcg_at_10",
-        "eval_next-item/ndcg_at_20",
-        "eval_next-item/recall_at_10",
-        "eval_next-item/recall_at_20",
-        "eval_loss",
+        "eval_/next-item/ndcg_at_10",
+        "eval_/next-item/ndcg_at_20",
+        "eval_/next-item/recall_at_10",
+        "eval_/next-item/recall_at_20",
+        "eval_/loss",
     ]
 
     result_1 = recsys_trainer.evaluate(eval_dataset=data.path, metric_key_prefix="eval")

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -584,12 +584,12 @@ class Trainer(BaseTrainer):
         if self.compute_metrics:
             streaming_metrics_results = model.compute_metrics(mode=metric_key_prefix)
             streaming_metrics_results_flattened = process_metrics(
-                streaming_metrics_results, prefix=metric_key_prefix + "_"
+                streaming_metrics_results, prefix=metric_key_prefix + "_/"
             )
 
             metrics = {**metrics, **streaming_metrics_results_flattened}
 
-        metrics[f"{metric_key_prefix}_loss"] = all_losses.mean().item()
+        metrics[f"{metric_key_prefix}_/loss"] = all_losses.mean().item()
 
         return EvalLoopOutput(
             predictions=all_preds_item_ids_scores,
@@ -762,7 +762,6 @@ class Trainer(BaseTrainer):
 
 
 def process_metrics(metrics, prefix="", to_cpu=True):
-    prefix = prefix.replace("/", "_")
     metrics_proc = {}
     for root_key, root_value in metrics.items():
         if isinstance(root_value, dict):

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -584,12 +584,12 @@ class Trainer(BaseTrainer):
         if self.compute_metrics:
             streaming_metrics_results = model.compute_metrics(mode=metric_key_prefix)
             streaming_metrics_results_flattened = process_metrics(
-                streaming_metrics_results, prefix=metric_key_prefix + "/"
+                streaming_metrics_results, prefix=metric_key_prefix + "_"
             )
 
             metrics = {**metrics, **streaming_metrics_results_flattened}
 
-        metrics[f"{metric_key_prefix}/loss"] = all_losses.mean().item()
+        metrics[f"{metric_key_prefix}_loss"] = all_losses.mean().item()
 
         return EvalLoopOutput(
             predictions=all_preds_item_ids_scores,
@@ -762,6 +762,7 @@ class Trainer(BaseTrainer):
 
 
 def process_metrics(metrics, prefix="", to_cpu=True):
+    prefix = prefix.replace("/", "_")
     metrics_proc = {}
     for root_key, root_value in metrics.items():
         if isinstance(root_value, dict):


### PR DESCRIPTION
### Goals :soccer:

HuggingFace [trainer](https://github.com/huggingface/transformers/blob/ac98a88fbc6377f93e8b7fbd244b0c3331bb82a0/src/transformers/trainer.py#L2924) class is expecting metrics prefixed with the following pattern `{metric_key_prefix}_`. In T4Rec, we were using the `\` separator to append the prefix to the metric name while HF is using the `_` separator. This PR is a quick fix that replaces `\` with `_` to align with HF code. 

### Testing Details :mag:
Updates the related tests that check the output metric names. 
