### PR TITLE
Update processing csv file text in tutorial nb

### DIFF
--- a/examples/t4rec_paper_experiments/README.md
+++ b/examples/t4rec_paper_experiments/README.md
@@ -57,7 +57,7 @@ This example script was implemented using the released PyTorch API of the Transf
 
 To reproduce the paper experiments with this example, you just need to perform two replacements in the [original scripts command lines](https://github.com/NVIDIA-Merlin/publications/blob/main/2021_acm_recsys_transformers4rec/experiments_reproducibility_commands.md):
 1. Replace the Python package name and script  `hf4rec.recsys_main` by `t4r_paper_repro.transf_exp_main`
-2. Replace the argument `--feature_config [.yaml file path]` by `--features_schema_path [schema file path]`, as previoulsy we used an YAML file to configure dataset features and now we use a features schema protobuf text file for the same purpose.
+2. Replace the argument `--feature_config [.yaml file path]` by `--features_schema_path [schema file path]`, as previously we used an YAML file to configure dataset features and now we use a features schema protobuf text file for the same purpose.
 3. For experiments using multiple features (RQ3), include the `--use_side_information_features` argument
 
 Below is the updated command to reproduce the experiment [TRANSFORMERS WITH MULTIPLE FEATURES - XLNet (MLM)](https://github.com/NVIDIA-Merlin/publications/blob/main/2021_acm_recsys_transformers4rec/experiments_reproducibility_commands.md#xlnet-mlm) for the REES46 ECOMMERCE DATASET.

--- a/examples/tutorial/01-preprocess.ipynb
+++ b/examples/tutorial/01-preprocess.ipynb
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "At this point we expect that you have already downloaded the `2019-Oct.csv` dataset and stored it in the `INPUT_DATA_DIR` as defined below. It is worth mentioning that the raw dataset is ~ 6 GB, therefore a single GPU with 16 GB or less memory might run out of memory. To avoid that, you can directly start from the second notebook, `02-ETL_with_NVTabular`, using `'Oct-2019.parquet` provided in [here](https://drive.google.com/drive/folders/1GjNKerPMvEtQHt9Z37ncF1zFedDXL_RJ)."
+    "At this point we expect that you have already downloaded the `2019-Oct.csv` dataset and stored it in the `INPUT_DATA_DIR` as defined below. It is worth mentioning that the raw dataset is ~ 6 GB, therefore a single GPU with 16 GB or less memory might run out of memory."
    ]
   },
   {

--- a/examples/tutorial/02-ETL-with-NVTabular.ipynb
+++ b/examples/tutorial/02-ETL-with-NVTabular.ipynb
@@ -133,7 +133,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We already performed certain preprocessing steps on the first month (Oct-2019) of the raw dataset in the `01-preprocess` notebook: <br>\n",
+    "Even though the original dataset contains 7 months data files, we are going to use the first seven days of the `Oct-2019.csv` ecommerce dataset. We already performed certain preprocessing steps on the first month (Oct-2019) of the raw dataset in the `01-preprocess` notebook: <br>\n",
     "\n",
     "- we created `event_time_ts` column from `event_time` column which shows the time when event happened at (in UTC).\n",
     "- we created `prod_first_event_time_ts` column which indicates the timestamp that an item was seen first time.\n",
@@ -146,7 +146,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Even though the original dataset contains 7 months data files, we are going to use the first seven days of the `Oct-2019.csv` ecommerce dataset. We use cuDF to read the parquet file. "
+    "Below, we start by reading in `Oct-2019.parquet`with cuDF. In order to create and save `Oct-2019.parquet` file, please run [01-preprocess.ipynb](https://github.com/NVIDIA-Merlin/Transformers4Rec/tree/main/examples/tutorial) notebook first."
    ]
   },
   {

--- a/transformers4rec/config/trainer.py
+++ b/transformers4rec/config/trainer.py
@@ -46,7 +46,7 @@ class T4RecTrainingArguments(TrainingArguments):
     log_attention_weights : Optional[bool], bool
         Logs the inputs and attention weights
         each --eval_steps (only test set)"
-        bu default False
+        by default False
     learning_rate_num_cosine_cycles_by_epoch : Optional[int], int
         Number of cycles for by epoch when --lr_scheduler_type = cosine_with_warmup.
         The number of waves in the cosine schedule

--- a/transformers4rec/torch/features/sequence.py
+++ b/transformers4rec/torch/features/sequence.py
@@ -170,7 +170,7 @@ class TabularSequenceFeatures(TabularFeatures):
         max_sequence_length : Optional[int], optional
             Maximum sequence length for list features by default None
         continuous_projection : Optional[Union[List[int], int]], optional
-            If set, concatenate all numerical features and projet them by a number of MLP layers.
+            If set, concatenate all numerical features and project them by a number of MLP layers.
             The argument accepts a list with the dimensions of the MLP layers, by default None
         continuous_soft_embeddings : bool
             Indicates if the  soft one-hot encoding technique must be used to represent

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -259,7 +259,7 @@ class Trainer(BaseTrainer):
         optimizer: (:obj:`torch.optim.Optimizer`)
             The optimizer that will be used during training.
         num_warmup_steps: (:obj:`int`, `optional`)
-            The number of warmup steps to do. This is not required by all schedulers
+            The number of warm up steps to do. This is not required by all schedulers
             (hence the argument being optional),
             the function will raise an error if it's unset and the scheduler type requires it.
         num_training_steps: (:obj:`int`, `optional`)

--- a/transformers4rec/torch/utils/torch_utils.py
+++ b/transformers4rec/torch/utils/torch_utils.py
@@ -212,7 +212,7 @@ def one_hot_1d(
 
     Args:
         labels (torch.Tensor) : tensor with labels of shape :math:`(N, H, W)`,
-                                where N is batch siz. Each value is an integer
+                                where N is batch size. Each value is an integer
                                 representing correct classification.
         num_classes (int): number of classes in labels.
         device (Optional[torch.device]): the desired device of returned tensor.


### PR DESCRIPTION
In the current tutorial ETL notebook, we provide a google drive link for Oct-2019.parquet file however, due to cuDF version people might get some errors from NVT pipeline. Like in this ticket https://github.com/NVIDIA-Merlin/Transformers4Rec/issues/480

To avoid that, we ask people to download the raw csv file and run the 01-preprocess nb and create the parquet file at their end first before they run 02-ETL nb.

In this PR, we
- remove google drive link
- update  and clarify text


