### PR TITLE
[feature]Multi-GPU DistributedDataParallel Fixed

### DIFF
--- a/transformers4rec/torch/ranking_metric.py
+++ b/transformers4rec/torch/ranking_metric.py
@@ -23,6 +23,7 @@ import torchmetrics as tm
 from merlin_standard_lib import Registry
 
 from .utils import torch_utils
+from torchmetrics.utilities.data import dim_zero_cat
 
 ranking_metrics_registry = Registry.class_registry("torch.ranking_metrics")
 
@@ -55,7 +56,7 @@ class RankingMetric(tm.Metric):
 
     def compute(self):
         # Computing the mean of the batch metrics (for each cut-off at topk)
-        return torch.cat(self.metric_mean, axis=0).mean(0)
+        return dim_zero_cat(self.metric_mean).mean(0)
 
     @abstractmethod
     def _metric(self, ks: torch.Tensor, preds: torch.Tensor, target: torch.Tensor) -> torch.Tensor:

--- a/transformers4rec/torch/ranking_metric.py
+++ b/transformers4rec/torch/ranking_metric.py
@@ -19,11 +19,11 @@ from abc import abstractmethod
 
 import torch
 import torchmetrics as tm
+from torchmetrics.utilities.data import dim_zero_cat
 
 from merlin_standard_lib import Registry
 
 from .utils import torch_utils
-from torchmetrics.utilities.data import dim_zero_cat
 
 ranking_metrics_registry = Registry.class_registry("torch.ranking_metrics")
 

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -145,13 +145,13 @@ class Trainer(BaseTrainer):
 
         assert self.schema is not None, "schema is required to generate Train Dataloader"
 
-        #Set global_rank and global_size if DDP is used
-        if self.args.local_rank!=-1:
-            local_rank=self.args.local_rank
-            global_size=self.args.world_size
+        # Set global_rank and global_size if DDP is used
+        if self.args.local_rank != -1:
+            local_rank = self.args.local_rank
+            global_size = self.args.world_size
         else:
-            local_rank=None
-            global_size=None
+            local_rank = None
+            global_size = None
 
         return T4RecDataLoader.parse(self.args.data_loader_engine).from_schema(
             self.schema,

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -144,6 +144,15 @@ class Trainer(BaseTrainer):
             return self.train_dataloader
 
         assert self.schema is not None, "schema is required to generate Train Dataloader"
+
+        #Set global_rank and global_size if DDP is used
+        if self.args.local_rank!=-1:
+            local_rank=self.args.local_rank
+            global_size=self.args.world_size
+        else:
+            local_rank=None
+            global_size=None
+
         return T4RecDataLoader.parse(self.args.data_loader_engine).from_schema(
             self.schema,
             self.train_dataset_or_path,
@@ -152,6 +161,8 @@ class Trainer(BaseTrainer):
             drop_last=self.args.dataloader_drop_last,
             shuffle=True,
             shuffle_buffer_size=self.args.shuffle_buffer_size,
+            global_rank=local_rank,
+            global_size=global_size,
         )
 
     def get_eval_dataloader(self, eval_dataset=None):

--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -227,7 +227,7 @@ if dependencies.is_gpu_dataloader_available():
             self.set_dataset(buffer_size, engine, reader_kwargs)
 
             if (global_rank is not None) and (self.dataset.npartitions < global_size):
-                print(
+                logger.warning(
                     "UserWarning: User is advised to repartition the parquet file before training "
                     "so npartitions>=global_size. Cudf or pandas can be used for repartitioning "
                     "e.g.: df.to_parquet('file.parquet', row_group_size=N_ROWS/NPARTITIONS, engine"

--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -22,7 +22,6 @@ from torch.utils.data import DataLoader as PyTorchDataLoader
 from torch.utils.data import Dataset, IterableDataset
 
 from merlin_standard_lib import Registry, Schema, Tag
-import merlin.core
 
 from ...utils import dependencies
 
@@ -227,8 +226,8 @@ if dependencies.is_gpu_dataloader_available():
 
             self.set_dataset(buffer_size, engine, reader_kwargs)
 
-            if(global_rank!=None and self.dataset.npartitions<global_size):
-                self.dataset=self.dataset.repartition(npartitions=global_size)
+            if ((global_rank is not None) and (self.dataset.npartitions < global_size)):
+                self.dataset = self.dataset.repartition(npartitions=global_size)
 
             loader = DataLoader(
                 self.dataset,

--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -226,7 +226,7 @@ if dependencies.is_gpu_dataloader_available():
 
             self.set_dataset(buffer_size, engine, reader_kwargs)
 
-            if ((global_rank is not None) and (self.dataset.npartitions < global_size)):
+            if (global_rank is not None) and (self.dataset.npartitions < global_size):
                 self.dataset = self.dataset.repartition(npartitions=global_size)
 
             loader = DataLoader(

--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -227,6 +227,12 @@ if dependencies.is_gpu_dataloader_available():
             self.set_dataset(buffer_size, engine, reader_kwargs)
 
             if (global_rank is not None) and (self.dataset.npartitions < global_size):
+                print(
+                    "UserWarning: User is advised to repartition the parquet file before training "
+                    "so npartitions>=global_size. Cudf or pandas can be used for repartitioning "
+                    "e.g.: df.to_parquet('file.parquet', row_group_size=N_ROWS/NPARTITIONS, engine"
+                    "='pyarrow') as npartitions=nr_rows/row_group_size."
+                )
                 self.dataset = self.dataset.repartition(npartitions=global_size)
 
             loader = DataLoader(

--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -22,6 +22,7 @@ from torch.utils.data import DataLoader as PyTorchDataLoader
 from torch.utils.data import Dataset, IterableDataset
 
 from merlin_standard_lib import Registry, Schema, Tag
+import merlin.core
 
 from ...utils import dependencies
 
@@ -225,6 +226,9 @@ if dependencies.is_gpu_dataloader_available():
             self.drop_last = drop_last
 
             self.set_dataset(buffer_size, engine, reader_kwargs)
+
+            if(global_rank!=None and self.dataset.npartitions<global_size):
+                self.dataset=self.dataset.repartition(npartitions=global_size)
 
             loader = DataLoader(
                 self.dataset,


### PR DESCRIPTION
Fixes #456 

### Goals :soccer:
1. Support Multi-GPU `DistributedDataParallel` training for next-item-prediction tasks using `transformers4rec.Trainer` class for training.
2. Make sure the performance is as expected (i.e. faster training time than single GPU and `DataParallel` training).

### Implementation Details :construction:

- The dataset used with Multi-GPU `DistributedDataParallel` needs to have number of partitions equal or greater than number of GPUs i.e. `dataloader.datatset.npartition>=dataloader.args.global_size`. We must check the number of partitions of the dataset and re-partition it if needed.
-  When computing metrics in `DistributedDataParallel` mode, ` torch.cat(self.metric_mean, 0)` failed. It was replaced by `torchmetrics.utilities.data.dim_zero_cat()` that has the same functionality but works for `DistributedDataParallel` too.
- For the dataloader to work properly, correct values of `global_rank` and `global_size` must be passed to its constructor.

### Testing Details :mag:

- To test for `DistributedDataParallel` training make sure `CUDA_VISIBLE_DEVICES` is set correctly and run the script using torch distributed launch as shown below:

`python -m torch.distributed.launch --nproc_per_node $N_GPUS$ your_script.py --arguments`
