### PR TITLE
Set `ignore_masking` to True by default

### DIFF
--- a/tests/torch/model/test_head.py
+++ b/tests/torch/model/test_head.py
@@ -134,7 +134,7 @@ def test_item_prediction_loss_and_metrics(
     body = tr.SequentialBlock(input_module, tr.MLPBlock([64]))
     head = tr.Head(body, tr.NextItemPredictionTask(weight_tying=weight_tying), inputs=input_module)
 
-    body_outputs = body(torch_yoochoose_like)
+    body_outputs = body(torch_yoochoose_like, ignore_masking=False)
 
     trg_flat = input_module.masking.masked_targets.flatten()
     non_pad_mask = trg_flat != input_module.masking.padding_idx

--- a/tests/torch/test_losses.py
+++ b/tests/torch/test_losses.py
@@ -19,12 +19,12 @@ def test_item_prediction_with_label_smoothing_ce_loss(
         body, tr.NextItemPredictionTask(weight_tying=True, loss=custom_loss), inputs=input_module
     )
 
-    body_outputs = body(torch_yoochoose_like)
+    body_outputs = body(torch_yoochoose_like, ignore_masking=False)
 
     trg_flat = input_module.masking.masked_targets.flatten()
     non_pad_mask = trg_flat != input_module.masking.padding_idx
     labels_all = pytorch.masked_select(trg_flat, non_pad_mask)
-    predictions = head(body_outputs)
+    predictions = head(body_outputs, ignore_masking=False)
 
     loss = head.prediction_task_dict["next-item"].compute_loss(
         inputs=body_outputs,

--- a/transformers4rec/torch/block/base.py
+++ b/transformers4rec/torch/block/base.py
@@ -139,7 +139,7 @@ class SequentialBlock(BlockBase, torch.nn.Sequential):
         # pylint: disable=arguments-out-of-order
         return right_shift_block(other, self)
 
-    def forward(self, input, training=True, ignore_masking=False, **kwargs):
+    def forward(self, input, training=True, ignore_masking=True, **kwargs):
         # from transformers4rec.torch import TabularSequenceFeatures
 
         for i, module in enumerate(self):

--- a/transformers4rec/torch/experimental.py
+++ b/transformers4rec/torch/experimental.py
@@ -78,7 +78,7 @@ class PostContextFusion(TabularBlock):
         elif fusion_aggregation == "concat":
             self.last_dim = hidden_dim + post_context_last_dim
 
-    def forward(self, inputs, training=False, ignore_masking=False, **kwargs):
+    def forward(self, inputs, training=False, ignore_masking=True, **kwargs):
         seq_rep = self.sequential_module(
             inputs, training=training, ignore_masking=ignore_masking, **kwargs
         )

--- a/transformers4rec/torch/features/sequence.py
+++ b/transformers4rec/torch/features/sequence.py
@@ -247,7 +247,7 @@ class TabularSequenceFeatures(TabularFeatures):
 
         return None
 
-    def forward(self, inputs, training=True, ignore_masking=False, **kwargs):
+    def forward(self, inputs, training=True, ignore_masking=True, **kwargs):
         outputs = super(TabularSequenceFeatures, self).forward(inputs)
 
         if self.masking or self.projection_module:

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -214,7 +214,7 @@ class NextItemPredictionTask(PredictionTask):
             body, input_size, device=device, inputs=inputs, task_block=task_block, pre=pre
         )
 
-    def forward(self, inputs: torch.Tensor, ignore_masking=False, **kwargs):
+    def forward(self, inputs: torch.Tensor, ignore_masking=True, **kwargs):
         if isinstance(inputs, (tuple, list)):
             inputs = inputs[0]
         x = inputs.float()
@@ -274,7 +274,7 @@ class NextItemPredictionTask(PredictionTask):
 
         outputs = {}
         if forward:
-            predictions = self(predictions)
+            predictions = self(predictions, ignore_masking=False)
             if self.hf_format:
                 targets = predictions["labels"]
                 predictions = predictions["predictions"]


### PR DESCRIPTION
Fixes https://github.com/NVIDIA-Merlin/NVTabular/issues/1688 

- This is a quick fix to set `ignore_masking` to True in the model's forward method.
- The motivation behind this fix is that during prediction/inference, we always want to use the whole input sequence without any masking. 