### PR TITLE
Change nvtabular.io import to merlin.io.dataset

### DIFF
--- a/merlin_standard_lib/utils/misc_utils.py
+++ b/merlin_standard_lib/utils/misc_utils.py
@@ -196,7 +196,7 @@ def validate_dataset(paths_or_dataset, batch_size, buffer_size, engine, reader_k
         Additional arguments of the specified reader.
     """
     try:
-        from nvtabular.io import Dataset
+        from merlin.io.dataset import Dataset
     except ImportError:
         raise ValueError("NVTabular is necessary for this function, please install: " "nvtabular.")
 


### PR DESCRIPTION
importing nvtabular.io is deprecated and causes crashes.
`nvtabular.io` redirects to `merlin.io` for backwards compatibility, but `merlin.io` no longer contains `Dataset`.
Instead, it should be `merlin.io.dataset.Dataset`.

Fixes #484 
