### PR TITLE
Add save/load & input/output schema methods to T4Rec Model class 

### DIFF
--- a/tests/torch/model/test_model.py
+++ b/tests/torch/model/test_model.py
@@ -43,10 +43,10 @@ def test_simple_model(torch_tabular_features, torch_tabular_data):
     losses = model.fit(dataset, num_epochs=5)
     metrics = model.evaluate(dataset, mode="eval")
 
-    in_schema = model.input_schema(max_sequence_length=20)
+    in_schema = model.input_schema
     assert isinstance(in_schema, Core_Schema)
     assert set(in_schema.column_names) == set(inputs.schema.column_names)
-    out_schema = model.output_schema()
+    out_schema = model.output_schema
     assert isinstance(out_schema, Core_Schema)
     assert len(out_schema) == 1
     assert out_schema.column_names[0] == "target/binary_classification_task"
@@ -149,21 +149,14 @@ def test_model_with_multiple_heads_and_tasks(
     assert len(losses) == 5
     assert all(loss is not None for loss in losses)
 
-    # Get input schema
-    with pytest.raises(ValueError) as exc_info:
-        model.input_schema()
-        assert "You should specify the `max_sequence_length` of your list input" in str(
-            exc_info.value
-        )
-
-    in_schema = model.input_schema(max_sequence_length=20)
+    in_schema = model.input_schema
     assert isinstance(in_schema, Core_Schema)
     assert set(in_schema.column_names) == set(
         non_sequential_features_schema.column_names
         + torch_yoochoose_tabular_transformer_features.schema.column_names
     )
     # Get output schema
-    out_schema = model.output_schema()
+    out_schema = model.output_schema
     assert isinstance(out_schema, Core_Schema)
     assert set(out_schema.column_names) == set(output.keys())
 
@@ -234,11 +227,11 @@ def test_item_prediction_transformer_torch_model_from_config(
     assert out.size()[1] == task.target_dim
     assert len(out.size()) == 2
 
-    in_schema = model.input_schema(max_sequence_length=20)
+    in_schema = model.input_schema
     assert isinstance(in_schema, Core_Schema)
     assert set(in_schema.column_names).issubset(yoochoose_schema.column_names)
     # Get output schema
-    out_schema = model.output_schema()
+    out_schema = model.output_schema
     assert isinstance(out_schema, Core_Schema)
     assert len(out_schema) == 1
     assert out_schema.column_names[0] == "next-item"
@@ -331,12 +324,12 @@ def test_save_next_item_prediction_model(
     output = loaded_model(torch_yoochoose_like, training=False)
     assert isinstance(output, torch.Tensor)
 
-    in_schema = loaded_model.input_schema(max_sequence_length=20)
+    in_schema = loaded_model.input_schema
 
     assert isinstance(in_schema, Core_Schema)
     assert set(in_schema.column_names) == set(inputs.schema.column_names)
 
-    out_schema = loaded_model.output_schema()
+    out_schema = loaded_model.output_schema
     assert isinstance(out_schema, Core_Schema)
     assert len(out_schema) == 1
     assert out_schema.column_names[0] == "next-item"

--- a/tests/torch/model/test_model.py
+++ b/tests/torch/model/test_model.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 
+import os
+import tempfile
+
 import pytest
+import torch
+from merlin.schema import Schema as Core_Schema
 
 from transformers4rec.config import transformer as tconf
 
@@ -37,6 +42,14 @@ def test_simple_model(torch_tabular_features, torch_tabular_data):
     dataset = [(torch_tabular_data, targets)]
     losses = model.fit(dataset, num_epochs=5)
     metrics = model.evaluate(dataset, mode="eval")
+
+    in_schema = model.input_schema(max_sequence_length=20)
+    assert isinstance(in_schema, Core_Schema)
+    assert set(in_schema.column_names) == set(inputs.schema.column_names)
+    out_schema = model.output_schema()
+    assert isinstance(out_schema, Core_Schema)
+    assert len(out_schema) == 1
+    assert out_schema.column_names[0] == "target/binary_classification_task"
 
     # assert list(metrics.keys()) == ["precision", "recall", "accuracy"]
     assert len(metrics) == 3
@@ -118,6 +131,9 @@ def test_model_with_multiple_heads_and_tasks(
     # Final model with two heads
     model = tr.Model(head_1, head_2)
 
+    # get output of the model
+    output = model(torch_yoochoose_like)
+
     # launch training
     targets.update(targets_2)
     dataset = [(torch_yoochoose_like, targets)]
@@ -132,6 +148,24 @@ def test_model_with_multiple_heads_and_tasks(
     ]
     assert len(losses) == 5
     assert all(loss is not None for loss in losses)
+
+    # Get input schema
+    with pytest.raises(ValueError) as exc_info:
+        model.input_schema()
+        assert "You should specify the `max_sequence_length` of your list input" in str(
+            exc_info.value
+        )
+
+    in_schema = model.input_schema(max_sequence_length=20)
+    assert isinstance(in_schema, Core_Schema)
+    assert set(in_schema.column_names) == set(
+        non_sequential_features_schema.column_names
+        + torch_yoochoose_tabular_transformer_features.schema.column_names
+    )
+    # Get output schema
+    out_schema = model.output_schema()
+    assert isinstance(out_schema, Core_Schema)
+    assert set(out_schema.column_names) == set(output.keys())
 
 
 def test_multi_head_model_wrong_weights(torch_tabular_features, torch_yoochoose_like):
@@ -200,6 +234,15 @@ def test_item_prediction_transformer_torch_model_from_config(
     assert out.size()[1] == task.target_dim
     assert len(out.size()) == 2
 
+    in_schema = model.input_schema(max_sequence_length=20)
+    assert isinstance(in_schema, Core_Schema)
+    assert set(in_schema.column_names).issubset(yoochoose_schema.column_names)
+    # Get output schema
+    out_schema = model.output_schema()
+    assert isinstance(out_schema, Core_Schema)
+    assert len(out_schema) == 1
+    assert out_schema.column_names[0] == "next-item"
+
 
 @pytest.mark.parametrize("device", devices)
 def test_set_model_to_device(
@@ -249,7 +292,7 @@ def test_with_d_model_different_from_item_dim(torch_yoochoose_like, yoochoose_sc
     assert model(torch_yoochoose_like)
 
 
-@pytest.mark.parametrize("masking", ["causal", "mlm", "rtd", "plm"])
+@pytest.mark.parametrize("masking", ["causal", "mlm", "plm", "rtd"])
 def test_output_shape_mode_eval(torch_yoochoose_like, yoochoose_schema, masking):
     input_module = tr.TabularSequenceFeatures.from_schema(
         yoochoose_schema,
@@ -265,3 +308,35 @@ def test_output_shape_mode_eval(torch_yoochoose_like, yoochoose_schema, masking)
 
     out = model(torch_yoochoose_like, training=False)
     assert out["predictions"].shape[0] == torch_yoochoose_like["item_id/list"].size(0)
+
+
+def test_save_next_item_prediction_model(
+    torch_yoochoose_tabular_transformer_features, torch_yoochoose_like
+):
+    inputs = torch_yoochoose_tabular_transformer_features
+    transformer_config = tconf.XLNetConfig.build(100, 4, 2, 20)
+    task = tr.NextItemPredictionTask(hf_format=True, weight_tying=True)
+    model = transformer_config.to_torch_model(inputs, task)
+    output = model(torch_yoochoose_like, training=False)
+    assert isinstance(output, dict)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model.save(tmpdir)
+        assert "t4rec_model_class.pkl" in os.listdir(tmpdir)
+        loaded_model = model.load(tmpdir)
+        # deactivate the hf_format model to get the tensor of predictions as output
+        # instead of a dictionary of three tensors `loss, labels, and predictions`
+        loaded_model.hf_format = False
+
+    output = loaded_model(torch_yoochoose_like, training=False)
+    assert isinstance(output, torch.Tensor)
+
+    in_schema = loaded_model.input_schema(max_sequence_length=20)
+
+    assert isinstance(in_schema, Core_Schema)
+    assert set(in_schema.column_names) == set(inputs.schema.column_names)
+
+    out_schema = loaded_model.output_schema()
+    assert isinstance(out_schema, Core_Schema)
+    assert len(out_schema) == 1
+    assert out_schema.column_names[0] == "next-item"

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -728,8 +728,14 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
             )
             is_ragged = is_list and value_count.get("min", 0) != value_count.get("max", 0)
             int_domain = {"min": column.int_domain.min, "max": column.int_domain.max}
-            shape = max_sequence_length if is_list else 1
-            properties = {"value_count": value_count, "int_domain": int_domain, "shape": shape}
+            batch_dim = [-1]
+            column_dim = [max_sequence_length] if is_list else [1]
+            properties = {
+                "value_count": value_count,
+                "int_domain": int_domain,
+                "shape": batch_dim + column_dim,
+            }
+
             col_schema = ColumnSchema(
                 name,
                 dtype=dtype,
@@ -773,14 +779,14 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                     properties = {
                         "value_count": {"min": max_sequence_length, "max": max_sequence_length},
                         "int_domain": int_domain,
-                        "shape": (max_sequence_length, target_dim),
+                        "shape": (-1, max_sequence_length, target_dim),
                     }
                     is_list = True
                 else:
                     properties = {
                         "value_count": {"min": 1, "max": 1},
                         "int_domain": int_domain,
-                        "shape": (target_dim),
+                        "shape": (-1, target_dim),
                     }
                     is_list = False
                 col_schema = ColumnSchema(

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -497,33 +497,36 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
 
 
 class Model(torch.nn.Module, LossMixin, MetricsMixin):
-    """Model class that can aggregate one of multiple heads.
-
-    Parameters
-    ----------
-    head: Head
-        One or more heads of the model.
-    head_weights: List[float], optional
-        Weight-value to use for each head.
-    head_reduction: str, optional
-        How to reduce the losses into a single tensor when multiple heads are used.
-    optimizer: Type[torch.optim.Optimizer]
-        Optimizer-class to use during fitting
-    name: str, optional
-        Name of the model.
-    """
-
     def __init__(
         self,
         *head: Head,
         head_weights: Optional[List[float]] = None,
         head_reduction: str = "mean",
         optimizer: Type[torch.optim.Optimizer] = torch.optim.Adam,
-        name=None,
-        hf_format=True,
+        name: str = None,
+        hf_format: bool = True,
     ):
-        """
-        #TODO
+        """Model class that can aggregate one or multiple heads.
+
+        Parameters
+        ----------
+        head: Head
+            One or more heads of the model.
+        head_weights: List[float], optional
+            Weight-value to use for each head.
+        head_reduction: str, optional
+            How to reduce the losses into a single tensor when multiple heads are used.
+        optimizer: Type[torch.optim.Optimizer]
+            Optimizer-class to use during fitting
+        name: str, optional
+            Name of the model.
+        hf_format: bool, optional
+            This parameter is specific to NextItemPredictionTask class and controls the format of
+            the output returned by the task. If `True`, the task returns a dictionary
+            with three tensors: loss, predictions, labels. Otherwise, it returns the tensor of
+            `predictions` scores.
+            Usually, hf_format is set to True during training and False during inference
+            By default True.
         """
         if head_weights:
             if not isinstance(head_weights, list):
@@ -725,7 +728,8 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
             )
             is_ragged = is_list and value_count.get("min", 0) != value_count.get("max", 0)
             int_domain = {"min": column.int_domain.min, "max": column.int_domain.max}
-            properties = {"value_count": value_count, "int_domain": int_domain}
+            shape = max_sequence_length if is_list else 1
+            properties = {"value_count": value_count, "int_domain": int_domain, "shape": shape}
             col_schema = ColumnSchema(
                 name,
                 dtype=dtype,
@@ -769,10 +773,15 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                     properties = {
                         "value_count": {"min": max_sequence_length, "max": max_sequence_length},
                         "int_domain": int_domain,
+                        "shape": (max_sequence_length, target_dim),
                     }
                     is_list = True
                 else:
-                    properties = {"value_count": {"min": 1, "max": 1}, "int_domain": int_domain}
+                    properties = {
+                        "value_count": {"min": 1, "max": 1},
+                        "int_domain": int_domain,
+                        "shape": (target_dim),
+                    }
                     is_list = False
                 col_schema = ColumnSchema(
                     name, dtype=np.float32, properties=properties, is_list=is_list, is_ragged=False

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -26,7 +26,6 @@ import torch
 import torchmetrics as tm
 from merlin.schema import ColumnSchema
 from merlin.schema import Schema as Core_Schema
-from merlin.schema import Tags
 from tqdm import tqdm
 from transformers.modeling_utils import SequenceSummary
 
@@ -563,7 +562,7 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                 # At inference, we just need the predictions tensors.
                 # TODO: We are simplifying the logic around `hf_format` in the multi-gpu
                 # support work.
-                if not training and not self.hf_format:
+                if not self.hf_format:
                     return outputs["predictions"]
             return outputs
 
@@ -718,22 +717,9 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
             dtype = {0: np.float32, 2: np.int64, 3: np.float32}[column.type]
             tags = column.tags
             is_list = column.value_count.max > 0
-            if is_list:
-                # T4Rec is only supporting padded dense input tensors with a
-                # fixed max_sequence_length
-                max_sequence_length = column.value_count.max
-            else:
-                max_sequence_length = 1
-
-            value_count = {"min": max_sequence_length, "max": max_sequence_length}
-            is_ragged = is_list and value_count.get("min", 0) != value_count.get("max", 0)
             int_domain = {"min": column.int_domain.min, "max": column.int_domain.max}
-            batch_dim = [-1]
-            column_dim = [max_sequence_length] if is_list else [1]
             properties = {
-                "value_count": value_count,
                 "int_domain": int_domain,
-                "shape": batch_dim + column_dim,
             }
 
             col_schema = ColumnSchema(
@@ -742,7 +728,7 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                 tags=tags,
                 properties=properties,
                 is_list=is_list,
-                is_ragged=is_ragged,
+                is_ragged=False,
             )
             core_schema[name] = col_schema
         return core_schema
@@ -750,8 +736,6 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
     @property
     def output_schema(self):
         from .prediction_task import BinaryClassificationTask, RegressionTask
-
-        max_sequence_length = self.input_schema.select_by_tag(Tags.LIST).first.value_count.max
 
         # if the model has one head with one task, the output is a tensor
         # if multiple heads and/or multiple prediction task, the output is a dictionary
@@ -764,19 +748,12 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                     isinstance(task, (BinaryClassificationTask, RegressionTask))
                     and not task.summary_type
                 ):
-                    properties = {
-                        "value_count": {"min": max_sequence_length, "max": max_sequence_length},
-                        "int_domain": int_domain,
-                        "shape": (-1, max_sequence_length, target_dim),
-                    }
                     is_list = True
                 else:
-                    properties = {
-                        "value_count": {"min": 1, "max": 1},
-                        "int_domain": int_domain,
-                        "shape": (-1, target_dim),
-                    }
                     is_list = False
+                properties = {
+                    "int_domain": int_domain,
+                }
                 col_schema = ColumnSchema(
                     name, dtype=np.float32, properties=properties, is_list=is_list, is_ragged=False
                 )

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -770,10 +770,12 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                         "value_count": {"min": max_sequence_length, "max": max_sequence_length},
                         "int_domain": int_domain,
                     }
+                    is_list = True
                 else:
                     properties = {"value_count": {"min": 1, "max": 1}, "int_domain": int_domain}
+                    is_list = False
                 col_schema = ColumnSchema(
-                    name, dtype=np.float32, properties=properties, is_list=False, is_ragged=False
+                    name, dtype=np.float32, properties=properties, is_list=is_list, is_ragged=False
                 )
                 output_cols.append(col_schema)
 

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -60,6 +60,7 @@ class BinaryClassificationTask(PredictionTask):
         metrics=DEFAULT_METRICS,
         summary_type="first",
     ):
+        self.target_dim = 1
         super().__init__(
             loss=loss,
             metrics=metrics,
@@ -96,6 +97,7 @@ class RegressionTask(PredictionTask):
         metrics=DEFAULT_METRICS,
         summary_type="first",
     ):
+        self.target_dim = 1
         super().__init__(
             loss=loss,
             metrics=metrics,
@@ -214,7 +216,12 @@ class NextItemPredictionTask(PredictionTask):
             body, input_size, device=device, inputs=inputs, task_block=task_block, pre=pre
         )
 
-    def forward(self, inputs: torch.Tensor, ignore_masking=True, training=False, **kwargs):
+    def forward(
+        self, inputs: torch.Tensor, ignore_masking=True, training=False, hf_format=None, **kwargs
+    ):
+        if hf_format is not None:
+            self.hf_format = hf_format
+
         if isinstance(inputs, (tuple, list)):
             inputs = inputs[0]
         x = inputs.float()

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -621,11 +621,6 @@ class Trainer(BaseTrainer):
         """
         import os
 
-        try:
-            import cloudpickle
-        except ImportError:
-            cloudpickle = None
-
         logger.info("Saving model...")
         output_dir = os.path.join(
             self.args.output_dir, f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}"
@@ -636,11 +631,7 @@ class Trainer(BaseTrainer):
         # save the serialized model
         if save_model_class:
             # TODO : fix serialization of DatasetSchema object
-            if cloudpickle is None:
-                raise ValueError("cloudpickle is required to save model class")
-
-            with open(os.path.join(output_dir, "model_class.pkl"), "wb") as out:
-                cloudpickle.dump(self.model.wrapper_module, out)
+            self.model.wrapper_module.save(output_dir)
 
     def load_model_trainer_states_from_checkpoint(self, checkpoint_path, model=None):
         """
@@ -664,7 +655,9 @@ class Trainer(BaseTrainer):
             except ImportError:
                 raise ImportError("cloudpickle is required to load model class")
             logger.info("Loading model class")
-            model = cloudpickle.load(open(os.path.join(checkpoint_path, "model_class.pkl"), "rb"))
+            model = cloudpickle.load(
+                open(os.path.join(checkpoint_path, "t4rec_model_class.pkl"), "rb")
+            )
 
         self.model = HFWrapper(model)
         logger.info("Loading weights of previously trained model")


### PR DESCRIPTION
Fixes #499

### Goals :soccer:
- Add save/load methods of T4Rec models using CloudPickle and following the protocol defined in [Merlin-Model](https://github.com/NVIDIA-Merlin/models/](https://github.com/NVIDIA-Merlin/models/pull/680/))

- Add an `input_schema` property to the T4Rec base class `Model`  that builds the model schema from the inputs modules of the heads and returns the merlin schema object. 

- Add an `output_schema` property to the T4Rec base class `Model` that builds the model schema from the predictions tasks specified in the heads and returns a merlin schema object with as many ColumnSchemas as the predictions tasks. 


### Implementation Details :construction:
- Add save/load methods to the T4Rec base class `Model` using `cloudpickle` and following the same protocol proposed in merlin models ([here](https://github.com/NVIDIA-Merlin/models/pull/680/))

- Add a `shape` property to input/output schema to provide the length/shape information of list features 

-  I used the code of this unit test in merlin [system](https://github.com/NVIDIA-Merlin/systems/blob/main/tests/integration/t4r/test_pytorch_backend.py#L60-L92) as a starting point to convert the input T4Rec schema to a merlin schema object. 

- The output schema is built based on the prediction tasks provided to the model. The stored information is: 
`name, int_domain, value_counts, is_list, shape, and is_ragged`. 

### Constraints

- The format of the T4Rec model outputs is not standardized and varies a lot based on the PredictionTask and some specific boolean flags such as `hf_format`. There is a working going on to simplify the output API format (#505) which will simplify the output of the model at inference (one prediction tensor is returned in the case of a single task learning or a dictionary of tensors where keys are the task name and values are the predictions tensors). 

- The output dictionary needs to be converted to a `NamedTuple` for PyTorch serving. 


### Testing Details :mag:
- Update model tests with testing input/output schemas. 
- Add a unit test `test_save_next_item_prediction_model`: saving/loading the model trained with the next item prediction task (the model used in the inference example)
