### PR TITLE
fixing name and bug in MeanReciprocalRankAt

### DIFF
--- a/tests/torch/test_ranking_metrics.py
+++ b/tests/torch/test_ranking_metrics.py
@@ -17,7 +17,7 @@
 import pytest
 import torch
 
-from transformers4rec.torch.ranking_metric import MeanRecipricolRankAt
+from transformers4rec.torch.ranking_metric import MeanReciprocalRankAt
 
 tr = pytest.importorskip("transformers4rec.torch")
 
@@ -47,7 +47,7 @@ def test_score_with_transform_onehot(torch_ranking_metrics_inputs, metric):
 
 
 def test_mean_recipricol_rank():
-    metric = MeanRecipricolRankAt()
+    metric = MeanReciprocalRankAt()
     metric.top_ks = [1, 2, 3, 4]
     metric.labels_onehot = False
     result = metric(

--- a/transformers4rec/torch/ranking_metric.py
+++ b/transformers4rec/torch/ranking_metric.py
@@ -280,9 +280,9 @@ class NDCGAt(RankingMetric):
 
 
 @ranking_metrics_registry.register_with_multiple_names("mrr_at", "mrr")
-class MeanRecipricolRankAt(RankingMetric):
+class MeanReciprocalRankAt(RankingMetric):
     def __init__(self, top_ks=None, labels_onehot=False):
-        super(MeanRecipricolRankAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
+        super(MeanReciprocalRankAt, self).__init__(top_ks=top_ks, labels_onehot=labels_onehot)
 
     def _metric(
         self, ks: torch.Tensor, scores: torch.Tensor, labels: torch.Tensor, log_base: int = 2
@@ -310,6 +310,7 @@ class MeanRecipricolRankAt(RankingMetric):
             device=scores.device, dtype=torch.float32
         )
         for index, k in enumerate(ks):
-            values, _ = (topk_labels[:, :k] / (torch.arange(k) + 1)).max(dim=1)
+            values, _ = (topk_labels[:, :k] / (torch.arange(k) + 1).to(
+                device=scores.device)).max(dim=1)
             results[:, index] = values
         return results


### PR DESCRIPTION
<!--

Thank you for contributing to Transformers4Rec :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes # (issue)
[BUG] #509
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Fixes the problem with one of the tensors always created on CPU even if data is processed with GPU.
Also name is corrected.
### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
Tensor is placed on the same device as previously created one.
### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
Other metrics are not tested so I don't have a guidance for the process and the bug/naming is rather straightforward so there is no tests.