### PR TITLE
quick fix: apply masking when training next item prediction

### DIFF
--- a/transformers4rec/torch/features/sequence.py
+++ b/transformers4rec/torch/features/sequence.py
@@ -256,7 +256,7 @@ class TabularSequenceFeatures(TabularFeatures):
         if self.projection_module:
             outputs = self.projection_module(outputs)
 
-        if self.masking and not ignore_masking:
+        if self.masking and (not ignore_masking or training):
             outputs = self.masking(
                 outputs, item_ids=self.to_merge["categorical_module"].item_seq, training=training
             )

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -394,7 +394,7 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
             body_outputs = self.body(body_outputs, training=training, ignore_masking=ignore_masking)
 
         for name, task in self.prediction_task_dict.items():
-            outputs[name] = task(body_outputs, ignore_masking=ignore_masking, **kwargs)
+            outputs[name] = task(body_outputs, ignore_masking=ignore_masking, training=training, **kwargs)
 
         if len(outputs) == 1 and not always_output_dict:
             return outputs[list(outputs.keys())[0]]

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -214,7 +214,7 @@ class NextItemPredictionTask(PredictionTask):
             body, input_size, device=device, inputs=inputs, task_block=task_block, pre=pre
         )
 
-    def forward(self, inputs: torch.Tensor, ignore_masking=True, **kwargs):
+    def forward(self, inputs: torch.Tensor, ignore_masking=True, training=False, **kwargs):
         if isinstance(inputs, (tuple, list)):
             inputs = inputs[0]
         x = inputs.float()
@@ -223,7 +223,7 @@ class NextItemPredictionTask(PredictionTask):
             x = self.task_block(x)  # type: ignore
 
         # Retrieve labels from masking
-        if not ignore_masking:
+        if training or not ignore_masking:
             labels = self.masking.masked_targets  # type: ignore
             trg_flat = labels.flatten()
             non_pad_mask = trg_flat != self.padding_idx


### PR DESCRIPTION
### Goals :soccer:
- Apply masking when training the `NextItemPredictionTask` through HF transfomers Trainer.

### Implementation Details :construction:
- Observed when training for the `NextItemPredictionTask` in the `forward()` function, the correct value is not set for the `ignore_masking` flag therefore the correct flow was not happening.
- Added the `training` flag to `NextItemPredictionTask.forward()` and passed the correct value to it from `Head.forward()` to make sure the forward function of NextItemPrediciton is following the correct flow during training.

### Testing Details :mag:
- You can test with any of the CI test that use the `NextItemPredictionTask` and use a debugger to follow the control flow inside `NextItemPredictionTask.forward()`
