### PR TITLE
run github action tests and lint via tox, with upstream deps installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           tox -e lint
       - name: Checking Manifest
         run: |
+          pip install check-manifest
           check-manifest .
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,24 +37,24 @@ jobs:
         run: |
           pip install check-manifest
           check-manifest .
-      - name: Build
-        run: |
-          python setup.py develop
-      - name: Run unittests
-        run: |
-          tox -e test-cpu
-      - name: Generate package for pypi
-        run: |
-          python setup.py sdist
-      - name: Upload artifacts to github
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist
-          path: dist
+      # - name: Build
+      #   run: |
+      #     python setup.py develop
+      # - name: Run unittests
+      #   run: |
+      #     tox -e test-cpu
+      # - name: Generate package for pypi
+      #   run: |
+      #     python setup.py sdist
+      # - name: Upload artifacts to github
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: dist
+      #     path: dist
       # Build docs, treat warnings as errors (TODO SPHINXOPTS="-W -q")
       - name: Building docs
         run: |
-          make -C docs html
+          tox -e docs
       - name: Upload HTML
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: Test
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
     tags:
       - v*
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -18,73 +18,60 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Ubuntu packages
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y protobuf-compiler pandoc
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[all]
-    - name: Lint with flake8
-      run: |
-        flake8 .
-    - name: Lint with black
-      run: |
-        black --check .
-    - name: Lint with isort
-      run: |
-        isort -c .
-    - name: Checking Manifest
-      run: |
-        check-manifest .
-    - name: Type-checks using mypy
-      run: |
-        mypy transformers4rec --install-types --non-interactive --no-strict-optional --ignore-missing-imports
-    - name: Spellcheck with codespell
-      run: |
-        codespell
-    - name: Build
-      run: |
-        python setup.py develop
-    - name: Run unittests
-      run: |
-        python -m pytest -rsx --cov-config tests/.coveragerc --cov-report term-missing --cov=. tests
-    - name: Generate package for pypi
-      run: |
-        python setup.py sdist
-    - name: Upload artifacts to github
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist
-        path: dist
-    # Build docs, treat warnings as errors (TODO SPHINXOPTS="-W -q")
-    - name: Building docs
-      run: |
-        make -C docs html 
-    - name: Upload HTML
-      uses: actions/upload-artifact@v2
-      with:
-        name: html-build-artifact
-        path: docs/build/html
-        if-no-files-found: error
-        retention-days: 1
-    - name: Store PR information
-      run: |
-        mkdir ./pr
-        echo ${{ github.event.number }}              > ./pr/pr.txt
-        echo ${{ github.event.pull_request.merged }} > ./pr/merged.txt
-        echo ${{ github.event.action }}              > ./pr/action.txt
-    - name: Upload PR information
-      uses: actions/upload-artifact@v2
-      with:
-        name: pr
-        path: pr/
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y protobuf-compiler pandoc
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip tox
+      - name: Lint with flake8, black, isort
+        run: |
+          tox -e lint
+      - name: Checking Manifest
+        run: |
+          check-manifest .
+      - name: Build
+        run: |
+          python setup.py develop
+      - name: Run unittests
+        run: |
+          tox -e test-cpu
+      - name: Generate package for pypi
+        run: |
+          python setup.py sdist
+      - name: Upload artifacts to github
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+      # Build docs, treat warnings as errors (TODO SPHINXOPTS="-W -q")
+      - name: Building docs
+        run: |
+          make -C docs html
+      - name: Upload HTML
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-build-artifact
+          path: docs/build/html
+          if-no-files-found: error
+          retention-days: 1
+      - name: Store PR information
+        run: |
+          mkdir ./pr
+          echo ${{ github.event.number }}              > ./pr/pr.txt
+          echo ${{ github.event.pull_request.merged }} > ./pr/merged.txt
+          echo ${{ github.event.action }}              > ./pr/action.txt
+      - name: Upload PR information
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
 
   release:
     name: Release
@@ -110,4 +97,3 @@ jobs:
         run: |
           pip install --upgrade wheel pip setuptools twine
           twine upload *
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,20 +37,20 @@ jobs:
         run: |
           pip install check-manifest
           check-manifest .
-      # - name: Build
-      #   run: |
-      #     python setup.py develop
-      # - name: Run unittests
-      #   run: |
-      #     tox -e test-cpu
-      # - name: Generate package for pypi
-      #   run: |
-      #     python setup.py sdist
-      # - name: Upload artifacts to github
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: dist
-      #     path: dist
+      - name: Build
+        run: |
+          python setup.py develop
+      - name: Run unittests
+        run: |
+          tox -e test-cpu
+      - name: Generate package for pypi
+        run: |
+          python setup.py sdist
+      - name: Upload artifacts to github
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
       # Build docs, treat warnings as errors (TODO SPHINXOPTS="-W -q")
       - name: Building docs
         run: |

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,4 +9,3 @@ tensorflow-estimator==2.6.*
 tensorflow-ranking>=0.4
 codespell
 click<8.1.0
-interrogate

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,4 @@
 check-manifest
-pytest>=5
-pytest-cov>=2
 black==20.8b1
 flake8
 isort
@@ -12,15 +10,3 @@ tensorflow-ranking>=0.4
 codespell
 click<8.1.0
 
-# docs
-Sphinx<3.6
-sphinx_rtd_theme==1.0.0
-sphinx-multiversion@git+https://github.com/mikemckiernan/sphinx-multiversion.git
-sphinxcontrib-copydirs@git+https://github.com/mikemckiernan/sphinxcontrib-copydirs.git
-sphinx-external-toc<0.4
-ipython==8.1.1
-jinja2<3.1
-markupsafe==2.0.1
-natsort==8.0.1
-myst-nb<0.14
-linkify-it-py<1.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,4 +9,4 @@ tensorflow-estimator==2.6.*
 tensorflow-ranking>=0.4
 codespell
 click<8.1.0
-
+interrogate

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,13 @@
+-r dev.txt
+
+Sphinx<3.6
+sphinx_rtd_theme==1.0.0
+sphinx-multiversion@git+https://github.com/mikemckiernan/sphinx-multiversion.git
+sphinxcontrib-copydirs@git+https://github.com/mikemckiernan/sphinxcontrib-copydirs.git
+sphinx-external-toc<0.4
+ipython==8.1.1
+jinja2<3.1
+markupsafe==2.0.1
+natsort==8.0.1
+myst-nb<0.14
+linkify-it-py<1.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,5 @@
+-r dev.txt
+-r pytorch.txt
+
+pytest>=5
+pytest-cov>=2

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,6 @@ commands =
     black --check --diff transformers4rec tests merlin_standard_lib
     isort -c . --skip .tox
     mypy transformers4rec --install-types --non-interactive --no-strict-optional --ignore-missing-imports
-    interrogate --config=pyproject.toml
     codespell --skip .tox
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,71 @@
+; For all tests that run in Github Actions, see
+; .github/workflows/cpu-ci.yml for the workflow definition.
+
+[tox]
+envlist = python3.8,test-gpu,test-cpu
+
+[testenv]
+commands =
+    pip install --upgrade pip
+    pip install .
+
+[testenv:test-cpu]
+; Runs in: Github Actions
+; Runs all CPU-based tests. NOTE: if you are using an M1 mac, this will fail. You need to
+; change the tensorflow dependency to `tensorflow-macos` in requirements/test-cpu.txt.
+deps = -rrequirements/test.txt
+commands =
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
+
+    python -m pytest -rsx --cov-config tests/.coveragerc --cov-report term-missing --cov=. tests
+
+[testenv:test-gpu]
+sitepackages=true
+; Runs in: Internal Jenkins
+; Runs GPU-based tests.
+; The jenkins jobs run on an image based on merlin-hugectr. This will include all cudf configuration
+; and other gpu-specific libraries that we can enxpect will always exist. Thus, we don't need
+; to install requirements.txt yet. As we get better at python environment isolation, we will
+; need to add some back.
+setenv = 
+    TF_GPU_ALLOCATOR=cuda_malloc_async
+deps =
+    -rrequirements/test.txt
+commands =
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git
+
+    python -m pytest -rsx --cov-config tests/.coveragerc --cov-report term-missing --cov=. tests
+
+[testenv:lint]
+; Runs in: Github Actions
+; Runs all lint/code checks and fails the PR if there are errors.
+; Install pre-commit-hooks to run these tests during development.
+deps = -rrequirements/dev.txt
+commands =
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
+    flake8 transformers4rec tests merlin_standard_lib
+    black --check --diff transformers4rec tests merlin_standard_lib
+    isort -c . --skip .tox
+    mypy transformers4rec --install-types --non-interactive --no-strict-optional --ignore-missing-imports
+    interrogate --config=pyproject.toml
+    codespell --skip .tox
+
+[testenv:docs]
+; Runs in: Github Actions
+; Generates documentation with sphinx. There are other steps in the Github Actions workflow
+; to publish the documentation on release.
+changedir = {toxinidir}
+deps = -rrequirements/docs.txt
+commands =
+    python -m sphinx.cmd.build -P -b html docs/source docs/build/html
+
+[testenv:docs-multi]
+; Run the multi-version build that is shown on GitHub Pages.
+changedir = {toxinidir}
+deps = -rrequirements/docs.txt
+commands =
+    sphinx-multiversion --dump-metadata docs/source docs/build/html | jq "keys"
+    sphinx-multiversion docs/source docs/build/html
+


### PR DESCRIPTION
This PR makes a couple of changes to how PR tests are run in github actions.

The most notable is that it will install the `main` branch of `NVTabular` and `core` before running the tests. This ensures that the repo will still work with any changes to the merlin repos that it depends on. Other than that, all of the same commands should be executed as before.

* Adds a `tox.ini` file and uses it to run lint / pytest
* Combines all of the lint steps into one (flake8, black, etc).
* Pulls/installs the latest branches of `NVTabular` and `core` before running tests.

The GPU/Jenkins changes are not included in this PR and can be done in a follow-up.

Note: there are a lot of whitespace changes in the yaml file due to my editor's auto-formatting, so it looks like there were more changes to `ci.yml` than there actually were. I can fix that if desired. You can hide the whitespace changes in the diff by adding `?w=1` to the URL.
