### PR TITLE
Do not commit unnecessary doc files

### DIFF
--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -38,7 +38,11 @@ jobs:
           sphinx-multiversion --dump-metadata docs/source docs/build/html | jq "keys"
       - name: Building docs (multiversion)
         run: |
-          sphinx-multiversion docs/source docs/build/html
+          sphinx-multiversion -d /tmp docs/source docs/build/html
+      - name: Delete unnecessary files
+        run: |
+          find docs/build/html -name .doctrees -exec rm -rf {} \;
+          find docs/build/html -name .buildinfo -exec rm -rf {} \;
       - name: Upload HTML
         uses: actions/upload-artifact@v2
         with:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,6 +102,7 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {
     "titles_only": True,
 }
+html_copy_source = False
 html_show_sourcelink = False
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
First, do not copy the doc source to
the build directory.

Next, use `/tmp` for Sphinx data, like
the doctrees.

Lastly, `rm -rf` the doctrees and buildinfo
from the build.

