### PR TITLE
Fix CI test based on the requirements of the new merlin loader 

### DIFF
--- a/ci/test_integration.sh
+++ b/ci/test_integration.sh
@@ -35,7 +35,7 @@ pip install -r requirements.txt
 cd t4r_paper_repro
 FEATURE_SCHEMA_PATH=../datasets_configs/ecom_rees46/rees46_schema.pbtxt
 pip install gdown
-gdown https://drive.google.com/uc?id=1payLwuwfa_QG6GvFVg4KT1w7dSkO-jPZ
+gdown https://drive.google.com/uc?id=1NCFZ5ya3zyxPsrmupEoc9UEm4sslAddV
 apt-get update -y
 apt-get install unzip -y
 DATA_PATH=/transformers4rec/examples/t4rec_paper_experiments/t4r_paper_repro/

--- a/transformers4rec/torch/losses.py
+++ b/transformers4rec/torch/losses.py
@@ -31,7 +31,7 @@ class LabelSmoothCrossEntropyLoss(_WeightedLoss):
             targets = (
                 torch.empty(size=(targets.size(0), n_classes), device=targets.device)
                 .fill_(smoothing / (n_classes - 1))
-                .scatter_(1, targets.data.unsqueeze(1), 1.0 - smoothing)
+                .scatter_(1, targets.data.unsqueeze(1).to(torch.int64), 1.0 - smoothing)
             )
         return targets
 

--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -225,6 +225,7 @@ if dependencies.is_gpu_dataloader_available():
             self.drop_last = drop_last
 
             self.set_dataset(buffer_size, engine, reader_kwargs)
+            self.dataset.schema = self.dataset.schema.select_by_name(conts + cats + labels)
 
             if (global_rank is not None) and (self.dataset.npartitions < global_size):
                 logger.warning(

--- a/transformers4rec/torch/utils/torch_utils.py
+++ b/transformers4rec/torch/utils/torch_utils.py
@@ -199,7 +199,7 @@ def create_output_placeholder(scores, ks):
 
 
 def tranform_label_to_onehot(labels, vocab_size):
-    return one_hot_1d(labels.reshape(-1), vocab_size, dtype=torch.float32).detach()
+    return one_hot_1d(labels.reshape(-1).to(torch.int64), vocab_size, dtype=torch.float32).detach()
 
 
 def one_hot_1d(


### PR DESCRIPTION
- The objective of the PR is to fix the failing CI test. The test was failing because nvtabular was updated to use the new merlin loader but T4Rec was built on top of the nvtabular one. In fact, the new loader changed how the input features dtypes are set and how the batch features are selected, which breaks some logic used in T4Rec. 

**Note:** This PR includes quick fixes to ensure the CI test is passing but we need to discuss/implement a long-term solution that ensures a stable integration of the new merlin loader in T4Rec: 

- [x]  In the previous loader, all features were set to int32 or float32 without taking into account their original types in the parquet file. In the new version, the type of the tensor returned matches the types specified in the source parquet files. The ecomrees46 dataset used in CI included a hexadecimal feature  (`user_session`) which raises an error in the new data loader as it expects to have only numerical data in the dataset. In this PR, a new dataset was uploaded to drive with `user_session` converted to numerical.

- [x] The previous loader used the names of the features specified in the parameters `conts, cats, and labels` to filter the inputs tensors returned by the data loader (even if the dataset schema contained additional column names). In the new version, it seems that the data loader will always return the features specified in the dataset schema and augment it with missing features from `conts, cats, and labels`. This breaks some logic in T4Rec blocks (like Stochastic-Swap noise that iterates over all inputs of the data loader without taking into account the model's schema )

- [x] Cast the dtype of targets to `int64` when using the `torch.scatter_` method (this method requires the index to be explicitly set at torch.int64)


