### PR TITLE
Fix dtype mismatch in CLM masking class due to new data loader changes 

### DIFF
--- a/transformers4rec/torch/masking.py
+++ b/transformers4rec/torch/masking.py
@@ -259,7 +259,9 @@ class CausalLanguageModeling(MaskSequence):
                 labels.size(0), dtype=torch.long, device=item_ids.device  # type: ignore
             )
             last_item_sessions = mask_labels.sum(dim=1) - 1
-            label_seq_trg_eval = torch.zeros(labels.shape, dtype=torch.long, device=item_ids.device)
+            label_seq_trg_eval = torch.zeros(
+                labels.shape, dtype=labels.dtype, device=item_ids.device
+            )
             label_seq_trg_eval[rows_ids, last_item_sessions] = labels[rows_ids, last_item_sessions]
             # Updating labels and mask
             labels = label_seq_trg_eval


### PR DESCRIPTION
This is a quick fix of the error raised by the ci tests related to `### GPT-2 (CLM) - Item Id feature` and `### Transformer-XL (CLM) - Item Id feature`. The cause of the error is the dtype mismatch between the sequence of item ids returned by the data loader (the new loader keeps the dtype specified in the original parquet file) and the tensor `label_seq_trg_eval` created in the CLM masking class to store the masked labels (was always set to `torch.long`)