### PR TITLE
Fix failing ci error related to `sparse_names` containing features that are not part of the model's schema

### DIFF
--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -314,7 +314,7 @@ if dependencies.is_gpu_dataloader_available():
                 continuous_features or schema.select_by_tag(Tag.CONTINUOUS).column_names
             )
             targets = targets or schema.select_by_tag(Tag.TARGETS).column_names
-
+            schema = schema.select_by_name(categorical_features + continuous_features + targets)
             sparse_names = sparse_names or schema.select_by_tag(Tag.LIST).column_names
             sparse_max = sparse_max or {name: max_sequence_length for name in sparse_names}
             nvt_loader = cls(


### PR DESCRIPTION
- The new loader is returning all features specified in the `dataset.schema`. T4Rec was built on a previous convention where the data loader was loading only features specified in the schema passed to the `Trainer` (that matches the schema used to construct the model).  
- A quick fix was implemented in a previous [PR](https://github.com/NVIDIA-Merlin/Transformers4Rec/pull/536) that filters out features from `dataset.schema` before calling the dataloader. However, `sparse_names` argument needs also to be filtered out to keep only the features of the `schema` used to build the model.

**Note:** I was able to catch another issue related to the types of features in the dataset stored in the [drive](https://drive.google.com/file/d/1NCFZ5ya3zyxPsrmupEoc9UEm4sslAddV/view?usp=sharing) (and used by ci test). In fact, the data contained a mix of float64 and float32 input features which breaks the input block of T4Rec as it expects all continuous features to have same type (to aggregate them into one vector).  So I updated the data by casting all columns to float32 and load it back to the drive.