### PR TITLE
Support to pre-trained embeddings initializer (trainable or not)

### DIFF
--- a/tests/torch/features/test_embedding.py
+++ b/tests/torch/features/test_embedding.py
@@ -151,6 +151,35 @@ def test_embedding_features_yoochoose_custom_initializers(yoochoose_schema, torc
     )
 
 
+@pytest.mark.parametrize("trainable", [True, False])
+def test_pre_trained_embeddings_initializer(yoochoose_schema, torch_yoochoose_like, trainable):
+    item_id_cardinality = (
+        yoochoose_schema.select_by_name("item_id/list").feature[0].int_domain.max + 1
+    )
+    embedding_dim = 64
+    pre_trained_item_embeddings = np.random.rand(item_id_cardinality, embedding_dim)
+
+    schema = yoochoose_schema.select_by_tag(Tag.CATEGORICAL)
+    emb_module = tr.EmbeddingFeatures.from_schema(
+        schema,
+        embedding_dims={"item_id/list": embedding_dim},
+        embeddings_initializers={
+            "item_id/list": tr.PretrainedEmbeddingsInitializer(
+                pre_trained_item_embeddings, trainable=trainable
+            ),
+        },
+    )
+
+    assert np.allclose(
+        emb_module.embedding_tables["item_id/list"].weight.detach().numpy(),
+        pre_trained_item_embeddings,
+    )
+
+    assert emb_module.embedding_tables["item_id/list"].weight.requires_grad == trainable
+
+    _ = emb_module(torch_yoochoose_like)
+
+
 def test_soft_embedding_invalid_num_embeddings():
     with pytest.raises(AssertionError) as excinfo:
         tr.SoftEmbedding(num_embeddings=0, embeddings_dim=16)

--- a/tests/torch/features/test_embedding.py
+++ b/tests/torch/features/test_embedding.py
@@ -176,7 +176,6 @@ def test_pre_trained_embeddings_initializer(yoochoose_schema, torch_yoochoose_li
     )
 
     assert emb_module.embedding_tables["item_id/list"].weight.requires_grad == trainable
-
     _ = emb_module(torch_yoochoose_like)
 
 

--- a/transformers4rec/torch/__init__.py
+++ b/transformers4rec/torch/__init__.py
@@ -40,6 +40,7 @@ from .features.continuous import ContinuousFeatures
 from .features.embedding import (
     EmbeddingFeatures,
     FeatureConfig,
+    PretrainedEmbeddingsInitializer,
     SoftEmbedding,
     SoftEmbeddingFeatures,
     TableConfig,
@@ -103,6 +104,7 @@ __all__ = [
     "ContinuousFeatures",
     "EmbeddingFeatures",
     "SoftEmbeddingFeatures",
+    "PretrainedEmbeddingsInitializer",
     "TabularSequenceFeatures",
     "SequenceEmbeddingFeatures",
     "FeatureConfig",

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -500,12 +500,12 @@ class SoftEmbedding(torch.nn.Module):
 
 
 class PretrainedEmbeddingsInitializer(torch.nn.Module):
-    def __init__(self, weights_matrix, trainable=False, **kwargs):
+    def __init__(self, weight_matrix, trainable=False, **kwargs):
         super().__init__(**kwargs)
-        self.weights_matrix = torch.tensor(weights_matrix)
+        self.weight_matrix = torch.tensor(weight_matrix)
         self.trainable = trainable
 
     def forward(self, x):
         with torch.no_grad():
-            x.copy_(self.weights_matrix)
+            x.copy_(self.weight_matrix)
         x.requires_grad = self.trainable

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -500,7 +500,29 @@ class SoftEmbedding(torch.nn.Module):
 
 
 class PretrainedEmbeddingsInitializer(torch.nn.Module):
-    def __init__(self, weight_matrix, trainable=False, **kwargs):
+    """
+    Initializer of embedding tables with pre-trained embeddings
+
+    Parameters
+    ----------
+    weight_matrix : Union[torch.Tensor, List[List[float]]]
+        A 2D torch or numpy tensor or lists of lists with the pre-trained
+        weights for embeddings. The expect dims are
+        (embedding_cardinality,embedding_dim). The embedding_cardinality
+        can be inferred from the column schema, for example,
+        `schema.select_by_name("item_id").feature[0].int_domain.max + 1`.
+        The first position of the embedding table is reserved for padded
+        items (id=0).
+    trainable : bool
+        Whether the embedding table should be trainable or not
+    """
+
+    def __init__(
+        self,
+        weight_matrix: Union[torch.Tensor, List[List[float]]],
+        trainable: bool = False,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.weight_matrix = torch.tensor(weight_matrix)
         self.trainable = trainable

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -497,3 +497,15 @@ class SoftEmbedding(torch.nn.Module):
         soft_one_hot_embeddings = (weights.unsqueeze(-1) * self.embedding_table.weight).sum(-2)
 
         return soft_one_hot_embeddings
+
+
+class PretrainedEmbeddingsInitializer(torch.nn.Module):
+    def __init__(self, weights_matrix, trainable=False, **kwargs):
+        super().__init__(**kwargs)
+        self.weights_matrix = torch.tensor(weights_matrix)
+        self.trainable = trainable
+
+    def forward(self, x):
+        with torch.no_grad():
+            x.copy_(self.weights_matrix)
+        x.requires_grad = self.trainable

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -15,7 +15,7 @@
 #
 
 from functools import partial
-from typing import Any, Callable, Dict, Optional, Text, Union
+from typing import Any, Callable, Dict, List, Optional, Text, Union
 
 import torch
 
@@ -202,9 +202,7 @@ class EmbeddingFeatures(InputBlock):
         if automatic_build and schema:
             output.build(
                 get_output_sizes_from_schema(
-                    schema,
-                    kwargs.get("batch_size", -1),
-                    max_sequence_length=max_sequence_length,
+                    schema, kwargs.get("batch_size", -1), max_sequence_length=max_sequence_length,
                 ),
                 schema=schema,
             )
@@ -384,9 +382,7 @@ class SoftEmbeddingFeatures(EmbeddingFeatures):
         if automatic_build and schema:
             output.build(
                 get_output_sizes_from_schema(
-                    schema,
-                    kwargs.get("batch_size", -1),
-                    max_sequence_length=max_sequence_length,
+                    schema, kwargs.get("batch_size", -1), max_sequence_length=max_sequence_length,
                 )
             )
 

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -524,7 +524,10 @@ class PretrainedEmbeddingsInitializer(torch.nn.Module):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.weight_matrix = torch.tensor(weight_matrix)
+        # The weight matrix is kept in CPU, but when forward() is called
+        # to initialize the embedding table weight will be copied to
+        # the embedding table device (e.g. cuda)
+        self.weight_matrix = torch.tensor(weight_matrix, device="cpu")
         self.trainable = trainable
 
     def forward(self, x):

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -202,7 +202,9 @@ class EmbeddingFeatures(InputBlock):
         if automatic_build and schema:
             output.build(
                 get_output_sizes_from_schema(
-                    schema, kwargs.get("batch_size", -1), max_sequence_length=max_sequence_length,
+                    schema,
+                    kwargs.get("batch_size", -1),
+                    max_sequence_length=max_sequence_length,
                 ),
                 schema=schema,
             )
@@ -382,7 +384,9 @@ class SoftEmbeddingFeatures(EmbeddingFeatures):
         if automatic_build and schema:
             output.build(
                 get_output_sizes_from_schema(
-                    schema, kwargs.get("batch_size", -1), max_sequence_length=max_sequence_length,
+                    schema,
+                    kwargs.get("batch_size", -1),
+                    max_sequence_length=max_sequence_length,
                 )
             )
 
@@ -497,14 +501,14 @@ class SoftEmbedding(torch.nn.Module):
 
 class PretrainedEmbeddingsInitializer(torch.nn.Module):
     """
-    Initializer of embedding tables with pre-trained embeddings
+    Initializer of embedding tables with pre-trained weights
 
     Parameters
     ----------
     weight_matrix : Union[torch.Tensor, List[List[float]]]
         A 2D torch or numpy tensor or lists of lists with the pre-trained
         weights for embeddings. The expect dims are
-        (embedding_cardinality,embedding_dim). The embedding_cardinality
+        (embedding_cardinality, embedding_dim). The embedding_cardinality
         can be inferred from the column schema, for example,
         `schema.select_by_name("item_id").feature[0].int_domain.max + 1`.
         The first position of the embedding table is reserved for padded


### PR DESCRIPTION
Fixes #267
Relates to [#471](https://github.com/NVIDIA-Merlin/Merlin/issues/471), #475 , #485 , and [RMP #211](https://github.com/NVIDIA-Merlin/Merlin/issues/211)

### Goals :soccer:
Introduces the `PretrainedEmbeddingsInitializer`, which allows initializing an embedding table matrix with pre-trained weights and make it trainable or not.
In collaboration with @angmc 

### Implementation Details :construction:
The signature is `PretrainedEmbeddingsInitializer(weights_matrix, trainable=False)`. The `weights_matrix` expects a 2D matrix in numpy, list or torch tensor).

### Testing Details :mag:
A test demonstrates how to use `PretrainedEmbeddingsInitializer` with `trainable` True and False.

```python
pre_trained_item_embeddings = np.random.rand(item_id_cardinality, embedding_dim)

emb_module = tr.EmbeddingFeatures.from_schema(
        schema,
        embedding_dims={"item_id/list": embedding_dim},
        embeddings_initializers={
            "item_id/list": tr.PretrainedEmbeddingsInitializer(
                pre_trained_item_embeddings, trainable=trainable
            ),
        },
    )
```
