### PR TITLE
Ignore protobuf in mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -50,3 +50,6 @@ ignore_missing_imports = True
 
 [mypy-tqdm.*]
 ignore_missing_imports = True
+
+[mypy-google.protobuf.*]
+ignore_missing_imports = True


### PR DESCRIPTION
```
merlin_standard_lib/utils/proto_utils.py:21: error: Library stubs not installed for "google.protobuf" (or incompatible with Python 3.8)
merlin_standard_lib/utils/proto_utils.py:21: note: Hint: "python3 -m pip install types-protobuf"
merlin_standard_lib/utils/proto_utils.py:21: note: (or run "mypy --install-types" to install all missing stub packages)
merlin_standard_lib/utils/proto_utils.py:21: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
merlin_standard_lib/utils/proto_utils.py:22: error: Library stubs not installed for "google.protobuf.message" (or incompatible with Python 3.8)
```