### PR TITLE
Fix error raised by latest Torchmetrics (0.11.0)

### DIFF
--- a/requirements/pytorch.txt
+++ b/requirements/pytorch.txt
@@ -1,2 +1,2 @@
 torch>=1.0
-torchmetrics==0.3.2
+torchmetrics

--- a/requirements/pytorch.txt
+++ b/requirements/pytorch.txt
@@ -1,2 +1,2 @@
 torch>=1.0
-torchmetrics>=0.8.0
+torchmetrics>=0.10.0

--- a/requirements/pytorch.txt
+++ b/requirements/pytorch.txt
@@ -1,2 +1,2 @@
 torch>=1.0
-torchmetrics
+torchmetrics>=0.8.0

--- a/tests/torch/test_trainer.py
+++ b/tests/torch/test_trainer.py
@@ -325,9 +325,9 @@ def test_evaluate_results(torch_yoochoose_next_item_prediction_model):
         (
             tr.BinaryClassificationTask("click", summary_type="mean"),
             [
-                "eval_/click/binary_classification_task/accuracy",
-                "eval_/click/binary_classification_task/precision",
-                "eval_/click/binary_classification_task/recall",
+                "eval_/click/binary_classification_task/binary_accuracy",
+                "eval_/click/binary_classification_task/binary_precision",
+                "eval_/click/binary_classification_task/binary_recall",
             ],
         ),
         (
@@ -446,9 +446,9 @@ def test_trainer_with_multiple_tasks():
         "eval_/next-item/avg_precision_at_20",
         "eval_/next-item/recall_at_10",
         "eval_/next-item/recall_at_20",
-        "eval_/click/binary_classification_task/accuracy",
-        "eval_/click/binary_classification_task/precision",
-        "eval_/click/binary_classification_task/recall",
+        "eval_/click/binary_classification_task/binary_accuracy",
+        "eval_/click/binary_classification_task/binary_precision",
+        "eval_/click/binary_classification_task/binary_recall",
         "eval_/play_percentage/regression_task/mean_squared_error",
     ]
 

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -46,9 +46,9 @@ class BinaryClassificationPrepareBlock(BuildableBlock):
 class BinaryClassificationTask(PredictionTask):
     DEFAULT_LOSS = torch.nn.BCELoss()
     DEFAULT_METRICS = (
-        tm.Precision(num_classes=2),
-        tm.Recall(num_classes=2),
-        tm.Accuracy(),
+        tm.Precision(num_classes=2, task="binary"),
+        tm.Recall(num_classes=2, task="binary"),
+        tm.Accuracy(task="binary"),
         # TODO: Fix this: tm.AUC()
     )
 


### PR DESCRIPTION
This PR fixes the error raised by the latest release of Torchmetrics: 

```  File "/usr/local/lib/python3.8/dist-packages/transformers4rec/torch/model/prediction_task.py", line 49, in BinaryClassificationTask
    tm.Precision(num_classes=2),
TypeError: __new__() missing 1 required positional argument: 'task'
```
It might fix issue #557 

### Goals :soccer:
- The PR: https://github.com/Lightning-AI/metrics/pull/1252 in Torchmetrics introduces a refactor of classification metrics. These metrics now require a `task` parameter to specify whether the metrics are for a 'binary', 'multiclass', or 'multilabel' task.  
- This PR updates the default binary metrics accordingly.
- It also unpins the Torchermetrics version specified in `requirements/pytorch.txt` to align with the version installed via `pip` or in merlin containers. So as we can catch such errors in GitHub actions as well. 
### Testing Details :mag:
- Update `test_trainer_with_multiple_tasks` and `test_trainer_music_streaming` with new metric names. 
