### PR TITLE
Install systems for testing notebooks

### DIFF
--- a/requirements/systems.txt
+++ b/requirements/systems.txt
@@ -1,0 +1,1 @@
+merlin-systems

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 -r dev.txt
 -r pytorch.txt
+-r systems.txt
 
 pytest>=5
 pytest-cov>=2

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/systems.git@{posargs:main}
 
 [testenv:test-cpu]
 ; Runs in: Github Actions


### PR DESCRIPTION
https://github.com/NVIDIA-Merlin/Transformers4Rec/pull/586 will be adding notebook tests but the examples depend on `merlin-systems`. This PR installs `merlin-systems` for tests that depend on systems.