### PR TITLE
Update branch name extraction for tag builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            branch=$(git branch -r --contains ${{ github.ref_name }} | sed -e 's/^[[:space:]]*origin\///')
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           tox -e test-cpu -- $branch
       - name: Generate package for pypi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} | sed -e 's/^[[:space:]]*origin\///')
           fi
           tox -e test-cpu -- $branch
       - name: Generate package for pypi

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -24,7 +24,6 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
-          raw=$(git branch -r --contains ${{ github.ref_name }})
-          branch=${raw/origin\/}
+          branch=$(git branch -r --contains ${{ github.ref_name }} | sed -e 's/^[[:space:]]*origin\///')
         fi
         cd ${{ github.workspace }}; tox -e test-gpu -- $branch

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -24,6 +24,6 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
-          branch=$(git branch -r --contains ${{ github.ref_name }} | sed -e 's/^[[:space:]]*origin\///')
+          branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
         fi
         cd ${{ github.workspace }}; tox -e test-gpu -- $branch


### PR DESCRIPTION
- Updates branch name logic for tag builds to handle leading whitespace and multiple branch names
  - `git branch -r --contains v0.1.16`, for example, returns `  origin/release-22.12`. The subsequent line in our workflow failed to remove the prefix `  origin/` because if doesn't currently handle this whitespace.
    - using `--format "%(refname:short)"` to ensure we only get the branch name and not leading whitespace
  - another issue is that this tag was pointing at multiple branches, and the main branch was selected.
    - using `--list '*release*'` to ensure we select the release branch name. There is still an edge case where we could have the tag pointing at multiple release branches, but that seem less likely to happen.
- The package publish failed on the last release due to the issues described above.
  - https://github.com/NVIDIA-Merlin/Transformers4Rec/actions/runs/3808721847