### PR TITLE
Fetch release branches so that we can figure out the release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            # fetch release branches (the branch name is not automatically fetched by the actions/checkout step)
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
+            # find the release branch that we're pointing at
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           tox -e test-cpu -- $branch

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -24,6 +24,9 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
+          # fetch release branches (the branch name is not automatically fetched by the actions/checkout step)
+          git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
+          # find the release branch that we're pointing at
           branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
         fi
         cd ${{ github.workspace }}; tox -e test-gpu -- $branch


### PR DESCRIPTION
Follow-up to #608 

Adds a fetch of the release branches so that we can figure out the release branch name that the tag corresponds to. This is required because the default checkout behaviour of the `actions/checkout` step is to fetch only the single commit without any branch names.

An alternative to this is to specify `fetch-depth: 0` on the `actions/checkout` step which will result in a full fetch of all commits, branches, and tags. However, that is slightly slower due to it fetching everything instead of the more minimal set of commit data. And would apply to every build the way it's setup now and not only for the publish.