### PR TITLE
move categorical_cardinalities out of the schema class

### DIFF
--- a/merlin_standard_lib/__init__.py
+++ b/merlin_standard_lib/__init__.py
@@ -18,11 +18,19 @@ from betterproto import Message
 from merlin.schema.io import proto_utils
 
 from .schema import schema
-from .schema.schema import ColumnSchema, Schema
+from .schema.schema import ColumnSchema, Schema, categorical_cardinalities
 from .schema.tag import Tag
 
 # Other monkey-patching
 Message.HasField = proto_utils.has_field  # type: ignore
 Message.copy = proto_utils.copy_better_proto_message  # type: ignore
 
-__all__ = ["ColumnSchema", "Schema", "schema", "Tag", "Registry", "RegistryMixin"]
+__all__ = [
+    "ColumnSchema",
+    "Schema",
+    "schema",
+    "Tag",
+    "Registry",
+    "RegistryMixin",
+    "categorical_cardinalities",
+]

--- a/merlin_standard_lib/schema/schema.py
+++ b/merlin_standard_lib/schema/schema.py
@@ -367,14 +367,6 @@ class Schema(_Schema):
 
         return Schema(selected_schemas)
 
-    def categorical_cardinalities(self) -> Dict[str, int]:
-        outputs = {}
-        for col in self:
-            if col.int_domain and col.int_domain.is_categorical:
-                outputs[col.name] = col.int_domain.max + 1
-
-        return outputs
-
     @property
     def column_names(self) -> List[str]:
         return [f.name for f in self.feature]
@@ -535,3 +527,12 @@ def _proto_text_to_better_proto(
     json_str = json_format.MessageToJson(json_format.ParseDict(d, message))
 
     return better_proto_message.__class__().from_json(json_str)
+
+
+def categorical_cardinalities(schema) -> Dict[str, int]:
+    outputs = {}
+    for col in schema:
+        if col.int_domain and col.int_domain.is_categorical:
+            outputs[col.name] = col.int_domain.max + 1
+
+    return outputs

--- a/merlin_standard_lib/utils/embedding_utils.py
+++ b/merlin_standard_lib/utils/embedding_utils.py
@@ -16,11 +16,11 @@
 
 import math
 
-from merlin_standard_lib import Schema
+from merlin_standard_lib import Schema, categorical_cardinalities
 
 
 def get_embedding_sizes_from_schema(schema: Schema, multiplier: float = 2.0):
-    cardinalities = schema.categorical_cardinalities()
+    cardinalities = categorical_cardinalities(schema)
 
     return {
         key: get_embedding_size_from_cardinality(val, multiplier)

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -15,7 +15,7 @@
 #
 import pytest
 
-from merlin_standard_lib import Tag
+from merlin_standard_lib import Tag, categorical_cardinalities
 from merlin_standard_lib.utils.embedding_utils import get_embedding_sizes_from_schema
 
 
@@ -27,7 +27,7 @@ def test_schema_from_yoochoose_schema(yoochoose_schema):
 
 def test_schema_cardinalities(yoochoose_schema):
     schema = yoochoose_schema
-    assert schema.categorical_cardinalities() == {
+    assert categorical_cardinalities(schema) == {
         "item_id/list": schema.select_by_name("item_id/list").feature[0].int_domain.max + 1,
         "category/list": schema.select_by_name("category/list").feature[0].int_domain.max + 1,
         "user_country": schema.select_by_name("user_country").feature[0].int_domain.max + 1,
@@ -38,7 +38,7 @@ def test_schema_cardinalities(yoochoose_schema):
 def test_schema_embedding_sizes_nvt(yoochoose_schema):
     pytest.importorskip("nvtabular")
     schema = yoochoose_schema
-    assert schema.categorical_cardinalities() == {"item_id/list": 51996, "category/list": 332}
+    assert categorical_cardinalities(schema) == {"item_id/list": 51996, "category/list": 332}
     embedding_sizes = schema.embedding_sizes_nvt(minimum_size=16, maximum_size=512)
     assert embedding_sizes == {"item_id/list": 512, "category/list": 41, "user_country": 16}
 
@@ -46,7 +46,7 @@ def test_schema_embedding_sizes_nvt(yoochoose_schema):
 def test_schema_embedding_sizes(yoochoose_schema):
     schema = yoochoose_schema.remove_by_name("session_id")
 
-    assert schema.categorical_cardinalities() == {
+    assert categorical_cardinalities(schema) == {
         "category/list": 333,
         "item_id/list": 51997,
         "user_country": 63,

--- a/tests/merlin_standard_lib/schema/test_schema.py
+++ b/tests/merlin_standard_lib/schema/test_schema.py
@@ -15,6 +15,7 @@
 
 import pytest
 
+from merlin_standard_lib import categorical_cardinalities
 from merlin_standard_lib.schema import schema
 
 
@@ -60,7 +61,7 @@ def test_column_schema_categorical_with_shape():
 
     assert col.shape.dim[0].size == 1
 
-    assert schema.Schema([col]).categorical_cardinalities() == dict(cat_1=1000 + 1)
+    assert categorical_cardinalities(schema.Schema([col])) == dict(cat_1=1000 + 1)
 
 
 def test_column_schema_categorical_with_value_count():

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Text, Union
 import torch
 from merlin.models.utils.doc_utils import docstring_parameter
 
-from merlin_standard_lib import Schema, Tag
+from merlin_standard_lib import Schema, Tag, categorical_cardinalities
 from merlin_standard_lib.utils.embedding_utils import get_embedding_sizes_from_schema
 
 from ..tabular.base import (
@@ -176,7 +176,7 @@ class EmbeddingFeatures(InputBlock):
         embeddings_initializers = embeddings_initializers or {}
 
         emb_config = {}
-        cardinalities = schema.categorical_cardinalities()
+        cardinalities = categorical_cardinalities(schema)
         for key, cardinality in cardinalities.items():
             embedding_size = embedding_dims.get(key, embedding_dim_default)
             embedding_initializer = embeddings_initializers.get(key, None)
@@ -353,7 +353,7 @@ class SoftEmbeddingFeatures(EmbeddingFeatures):
         embeddings_initializers = embeddings_initializers or {}
 
         sizes = {}
-        cardinalities = schema.categorical_cardinalities()
+        cardinalities = categorical_cardinalities(schema)
         for col_name in schema.column_names:
             # If this is NOT a categorical feature
             if col_name not in cardinalities:


### PR DESCRIPTION
Continued small-piece-at-a-time refactoring for https://github.com/NVIDIA-Merlin/Transformers4Rec/issues/566

This removes `categorical_cardinalities` from the `Schema` class, which does not exist on the `merlin.schema.Schema` class.

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
