### PR TITLE
Allow Schema class from core to be used to create input-blocks

### DIFF
--- a/merlin_standard_lib/schema/schema.py
+++ b/merlin_standard_lib/schema/schema.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar
 
 from google.protobuf import json_format, text_format
 from google.protobuf.message import Message as ProtoMessage
+from merlin.models.utils import schema_utils as mm_schema_utils
+from merlin.schema import Schema as CoreSchema
 from merlin.schema import Tags, TagSet, TagsType
 from merlin.schema.io import proto_utils
 
@@ -530,6 +532,9 @@ def _proto_text_to_better_proto(
 
 
 def categorical_cardinalities(schema) -> Dict[str, int]:
+    if isinstance(schema, CoreSchema):
+        return mm_schema_utils.categorical_cardinalities(schema)
+
     outputs = {}
     for col in schema:
         if col.int_domain and col.int_domain.is_categorical:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def tabular_core_schema(tabular_schema):
     return TensorflowMetadata.from_json(tabular_schema.to_json()).to_merlin_schema()
 
 
-def tabular_schemas():
+def parametrize_tabular_schemas():
     schema = tabular_testing_data.schema.remove_by_name(["session_id", "session_start", "day_idx"])
 
     return pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
+from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 
 from merlin_standard_lib import Schema
 from transformers4rec.data import tabular_sequence_testing_data, tabular_testing_data
@@ -71,6 +72,26 @@ def tabular_schema_file() -> str:
 @pytest.fixture
 def tabular_schema() -> Schema:
     return tabular_testing_data.schema.remove_by_name(["session_id", "session_start", "day_idx"])
+
+
+@pytest.fixture
+def tabular_core_schema(tabular_schema):
+    return TensorflowMetadata.from_json(tabular_schema.to_json()).to_merlin_schema()
+
+
+def tabular_schemas():
+    schema = tabular_testing_data.schema.remove_by_name(["session_id", "session_start", "day_idx"])
+
+    return pytest.mark.parametrize(
+        "schema",
+        [
+            pytest.param(schema, id="merlin-standard-lib"),
+            pytest.param(
+                TensorflowMetadata.from_json(schema.to_json()).to_merlin_schema(),
+                id="merlin-core",
+            ),
+        ],
+    )
 
 
 try:

--- a/tests/torch/features/test_tabular.py
+++ b/tests/torch/features/test_tabular.py
@@ -19,9 +19,11 @@ from merlin.schema import Tags
 
 import transformers4rec.torch as tr
 
+from ...conftest import tabular_schemas
 
-def test_tabular_features(tabular_schema, torch_tabular_data):
-    schema = tabular_schema
+
+@tabular_schemas()
+def test_tabular_features(schema, torch_tabular_data):
     tab_module = tr.TabularFeatures.from_schema(schema)
 
     outputs = tab_module(torch_tabular_data)
@@ -32,9 +34,8 @@ def test_tabular_features(tabular_schema, torch_tabular_data):
     )
 
 
-def test_tabular_features_embeddings_options(tabular_schema, torch_tabular_data):
-    schema = tabular_schema
-
+@tabular_schemas()
+def test_tabular_features_embeddings_options(schema, torch_tabular_data):
     EMB_DIM = 100
     tab_module = tr.TabularFeatures.from_schema(schema, embedding_dim_default=EMB_DIM)
 
@@ -44,8 +45,8 @@ def test_tabular_features_embeddings_options(tabular_schema, torch_tabular_data)
     assert all(v.shape[-1] == EMB_DIM for k, v in outputs.items() if k in categ_features)
 
 
-def test_tabular_features_with_projection(tabular_schema, torch_tabular_data):
-    schema = tabular_schema
+@tabular_schemas()
+def test_tabular_features_with_projection(schema, torch_tabular_data):
     tab_module = tr.TabularFeatures.from_schema(schema, continuous_projection=64)
 
     outputs = tab_module(torch_tabular_data)
@@ -57,9 +58,8 @@ def test_tabular_features_with_projection(tabular_schema, torch_tabular_data):
     assert list(outputs["continuous_projection"].shape)[1] == 64
 
 
-def test_tabular_features_soft_encoding(tabular_schema, torch_tabular_data):
-    schema = tabular_schema
-
+@tabular_schemas()
+def test_tabular_features_soft_encoding(schema, torch_tabular_data):
     emb_cardinality = 10
     emb_dim = 8
     tab_module = tr.TabularFeatures.from_schema(

--- a/tests/torch/features/test_tabular.py
+++ b/tests/torch/features/test_tabular.py
@@ -18,10 +18,10 @@
 from merlin.schema import Tags
 
 import transformers4rec.torch as tr
-from tests.conftest import tabular_schemas
+from tests.conftest import parametrize_tabular_schemas
 
 
-@tabular_schemas()
+@parametrize_tabular_schemas()
 def test_tabular_features(schema, torch_tabular_data):
     tab_module = tr.TabularFeatures.from_schema(schema)
 
@@ -33,7 +33,7 @@ def test_tabular_features(schema, torch_tabular_data):
     )
 
 
-@tabular_schemas()
+@parametrize_tabular_schemas()
 def test_tabular_features_embeddings_options(schema, torch_tabular_data):
     EMB_DIM = 100
     tab_module = tr.TabularFeatures.from_schema(schema, embedding_dim_default=EMB_DIM)
@@ -44,7 +44,7 @@ def test_tabular_features_embeddings_options(schema, torch_tabular_data):
     assert all(v.shape[-1] == EMB_DIM for k, v in outputs.items() if k in categ_features)
 
 
-@tabular_schemas()
+@parametrize_tabular_schemas()
 def test_tabular_features_with_projection(schema, torch_tabular_data):
     tab_module = tr.TabularFeatures.from_schema(schema, continuous_projection=64)
 
@@ -57,7 +57,7 @@ def test_tabular_features_with_projection(schema, torch_tabular_data):
     assert list(outputs["continuous_projection"].shape)[1] == 64
 
 
-@tabular_schemas()
+@parametrize_tabular_schemas()
 def test_tabular_features_soft_encoding(schema, torch_tabular_data):
     emb_cardinality = 10
     emb_dim = 8

--- a/tests/torch/features/test_tabular.py
+++ b/tests/torch/features/test_tabular.py
@@ -18,8 +18,7 @@
 from merlin.schema import Tags
 
 import transformers4rec.torch as tr
-
-from ...conftest import tabular_schemas
+from tests.conftest import tabular_schemas
 
 
 @tabular_schemas()

--- a/transformers4rec/torch/tabular/base.py
+++ b/transformers4rec/torch/tabular/base.py
@@ -15,6 +15,7 @@
 #
 
 from abc import ABC
+from copy import deepcopy
 from functools import reduce
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -186,7 +187,7 @@ class TabularModule(torch.nn.Module):
         -------
         Optional[TabularModule]
         """
-        schema_copy = schema.copy()
+        schema_copy = deepcopy(schema)
         if tags:
             schema_copy = schema_copy.select_by_tag(tags)
 

--- a/transformers4rec/torch/utils/torch_utils.py
+++ b/transformers4rec/torch/utils/torch_utils.py
@@ -21,9 +21,11 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 import torch
+from merlin.schema import Schema as CoreSchema
 from merlin.schema.io.proto_utils import has_field
 
 from merlin_standard_lib import Schema
+from merlin_standard_lib.schema.schema import ColumnSchema
 
 from ...config.schema import SchemaMixin
 from ..typing import TabularData
@@ -137,22 +139,42 @@ def check_gpu(module):
         return False
 
 
+def _has_field(col_schema, field_name):
+    if isinstance(col_schema, ColumnSchema):
+        return has_field(col_schema, field_name)
+
+    return getattr(col_schema, field_name, None)
+
+
+def _get_size_from_shape(col_schema, batch_size) -> torch.Size:
+    shape = [batch_size]
+
+    if isinstance(col_schema, ColumnSchema):
+        if has_field(col_schema, "shape"):
+            shape += [d.size for d in col_schema.shape.dim]
+    elif col_schema.shape.dims is not None:
+        raise NotImplementedError("TODO: support shape.dims")
+
+    return torch.Size(shape)
+
+
 def get_output_sizes_from_schema(schema: Schema, batch_size=-1, max_sequence_length=None):
     sizes = {}
-    for feature in schema.feature:
+
+    features = schema if isinstance(schema, CoreSchema) else schema.feature
+
+    for feature in features:
         name = feature.name
         # Sequential or multi-hot feature
-        if has_field(feature, "value_count"):
+        if _has_field(feature, "value_count"):
             sizes[name] = torch.Size(
                 [
                     batch_size,
                     max_sequence_length if max_sequence_length else feature.value_count.max,
                 ]
             )
-        elif has_field(feature, "shape"):
-            sizes[name] = torch.Size([batch_size] + [d.size for d in feature.shape.dim])
         else:
-            sizes[name] = torch.Size([batch_size])
+            sizes[name] = _get_size_from_shape(feature, batch_size)
 
     return sizes
 


### PR DESCRIPTION
### Goals :soccer:
The goal is to deprecate the `Schema` class in `merlin_standard_lib` in favor of the one in merlin-core. In order to give our users some time for this breaking change, this PR adds support for providing both the Schema definitions to create input-blocks. 

The next step would be to do the same for the `Trainer` class.

### Testing Details :mag:
This PR adds some parameterization in order to test the creation of input-blocks from both the Schema definitions.
