### PR TITLE
Fix the predictions returned by `Trainer.predict(..)`

### DIFF
--- a/tests/torch/model/test_head.py
+++ b/tests/torch/model/test_head.py
@@ -49,7 +49,7 @@ def test_simple_heads_on_sequence(
     if summary:
         targets = {"target": torch.randint(2, (100,)).float()}
     else:
-        targets = {"target": torch.randint(2, (2000,)).float()}
+        targets = {"target": torch.randint(2, (100, 20)).float()}
 
     body = tr.SequentialBlock(inputs, tr.MLPBlock([64]))
     head = task("target", task_block=task_block, summary_type=summary).to_head(body, inputs)

--- a/tests/torch/test_trainer.py
+++ b/tests/torch/test_trainer.py
@@ -383,12 +383,18 @@ def test_trainer_music_streaming(task_and_metrics):
     assert eval_metrics["eval_/loss"] is not None
 
     assert predictions is not None
+    # 1000 is the total samples in the testing data
+    if isinstance(task, tr.NextItemPredictionTask):
+        assert predictions.predictions.shape == (1000, task.target_dim)
+    else:
+        assert predictions.predictions.shape == (1000,)
 
 
 def test_trainer_with_multiple_tasks():
     data = tr.data.music_streaming_testing_data
     schema = data.schema
     batch_size = 16
+    predict_top_k = 20
     tasks = [
         tr.NextItemPredictionTask(weight_tying=True),
         tr.BinaryClassificationTask("click", summary_type="mean"),
@@ -417,7 +423,7 @@ def test_trainer_with_multiple_tasks():
         per_device_eval_batch_size=batch_size // 2,
         data_loader_engine="merlin_dataloader",
         max_sequence_length=20,
-        predict_top_k=20,
+        predict_top_k=predict_top_k,
         fp16=False,
         report_to=[],
         debug=["r"],
@@ -455,3 +461,48 @@ def test_trainer_with_multiple_tasks():
     assert eval_metrics["eval_/loss"] is not None
 
     assert predictions is not None
+    assert predictions.predictions["next-item"][0].shape == (1000, predict_top_k)
+    assert predictions.predictions["play_percentage/regression_task"].shape == (1000,)
+    assert predictions.predictions["click/binary_classification_task"].shape == (1000,)
+
+
+def test_trainer_trop_k_with_wrong_task():
+    data = tr.data.music_streaming_testing_data
+    schema = data.schema
+    batch_size = 16
+    predict_top_k = 20
+
+    task = tr.BinaryClassificationTask("click", summary_type="mean")
+    inputs = tr.TabularSequenceFeatures.from_schema(
+        schema,
+        max_sequence_length=20,
+        d_output=64,
+    )
+    transformer_config = tconf.XLNetConfig.build(64, 4, 2, 20)
+    model = transformer_config.to_torch_model(inputs, task)
+
+    args = trainer.T4RecTrainingArguments(
+        output_dir=".",
+        num_train_epochs=1,
+        per_device_train_batch_size=batch_size,
+        per_device_eval_batch_size=batch_size // 2,
+        data_loader_engine="merlin_dataloader",
+        max_sequence_length=20,
+        predict_top_k=predict_top_k,
+        report_to=[],
+        debug=["r"],
+    )
+
+    recsys_trainer = tr.Trainer(
+        model=model,
+        args=args,
+        schema=schema,
+        train_dataset_or_path=data.path,
+        eval_dataset_or_path=data.path,
+        test_dataset_or_path=data.path,
+        compute_metrics=True,
+    )
+    with pytest.raises(AssertionError) as excinfo:
+        recsys_trainer.predict(data.path)
+
+    assert "Top-k prediction is specific to NextItemPredictionTask" in str(excinfo.value)

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -36,7 +36,7 @@ from merlin_standard_lib import Schema
 from ..block.base import BlockBase, BlockOrModule, BlockType
 from ..features.base import InputBlock
 from ..features.sequence import TabularFeaturesType
-from ..typing import TabularData, TensorOrTabularData
+from ..typing import TabularData
 from ..utils.torch_utils import LossMixin, MetricsMixin
 
 
@@ -517,9 +517,7 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
         self.head_reduction = head_reduction
         self.optimizer = optimizer
 
-    def forward(
-        self, inputs: TensorOrTabularData, targets=None, training=False, testing=False, **kwargs
-    ):
+    def forward(self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs):
         # Convert inputs to float32 which is the default type, expected by PyTorch
         for name, val in inputs.items():
             if torch.is_floating_point(val):
@@ -783,6 +781,10 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                 output_cols.append(col_schema)
 
         return Core_Schema(output_cols)
+
+    @property
+    def prediction_tasks(self):
+        return [task for head in self.heads for task in list(head.prediction_task_dict.values())]
 
     def save(self, path: Union[str, os.PathLike], model_name="t4rec_model_class"):
         """Saves the model to f"{export_path}/{model_name}.pkl" using `cloudpickle`

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -167,6 +167,13 @@ class PredictionTask(torch.nn.Module, LossMixin, MetricsMixin):
         if training or testing:
             # add support of computing the loss inside the forward
             # and return a dictionary as standard output
+            if self.summary_type is None:
+                if targets.dim() != 2:
+                    raise ValueError(
+                        "If `summary_type==None`, targets are expected to be a 2D tensor, "
+                        f"but got a tensor with shape {targets.shape}"
+                    )
+
             loss = self.loss(x, target=targets)
             return {"loss": loss, "labels": targets, "predictions": x}
 

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -36,7 +36,7 @@ class BinaryClassificationPrepareBlock(BuildableBlock):
         return SequentialBlock(
             torch.nn.Linear(input_size[-1], 1, bias=False),
             torch.nn.Sigmoid(),
-            LambdaModule(lambda x: x.view(-1)),
+            LambdaModule(lambda x: torch.squeeze(x, -1)),
             output_size=[
                 None,
             ],
@@ -157,7 +157,7 @@ class RegressionPrepareBlock(BuildableBlock):
     def build(self, input_size) -> SequentialBlock:
         return SequentialBlock(
             torch.nn.Linear(input_size[-1], 1),
-            LambdaModule(lambda x: x.view(-1)),
+            LambdaModule(lambda x: torch.squeeze(x, -1)),
             output_size=[
                 None,
             ],

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -41,6 +41,7 @@ from merlin_standard_lib import Schema
 
 from ..config.trainer import T4RecTrainingArguments
 from .model.base import Model
+from .model.prediction_task import NextItemPredictionTask
 from .utils.data_utils import T4RecDataLoader
 from .utils.torch_utils import nested_concat, nested_detach, nested_numpify, nested_truncate
 
@@ -437,7 +438,7 @@ class Trainer(BaseTrainer):
         logger.info("***** Running %s *****", description)
         logger.info("  Batch size = %d", batch_size)
 
-        preds_item_ids_scores_host: Union[torch.Tensor, List[torch.Tensor]] = None
+        preds_host: Union[torch.Tensor, List[torch.Tensor], Dict[str, torch.Tensor]] = None
         labels_host: Union[torch.Tensor, List[torch.Tensor]] = None
 
         if metric_key_prefix == "train" and self.args.eval_steps_on_train_set:
@@ -454,11 +455,11 @@ class Trainer(BaseTrainer):
         # Initialize containers
         # losses/preds/labels on GPU/TPU (accumulated for eval_accumulation_steps)
         losses_host = None
-        preds_item_ids_scores_host = None
+        preds_host = None
         labels_host = None
         # losses/preds/labels on CPU (final containers)
         all_losses = None
-        all_preds_item_ids_scores = None
+        all_preds = None
         all_labels = None
         # Will be useful when we have an iterable dataset so don't know its length.
         observed_num_examples = 0
@@ -508,13 +509,20 @@ class Trainer(BaseTrainer):
                     else nested_concat(labels_host, labels, padding_index=0)
                 )
             if preds is not None and self.args.predict_top_k > 0:
+                # get outputs of next-item scores
                 if isinstance(preds, dict):
                     assert (
                         "next-item" in preds
                     ), "Top-k prediction is specific to NextItemPredictionTask"
-                    preds = preds["next-item"]
+                    pred_next_item = preds["next-item"]
+                else:
+                    assert isinstance(
+                        model.prediction_tasks[0], NextItemPredictionTask
+                    ), "Top-k prediction is specific to NextItemPredictionTask"
+                    pred_next_item = preds
+
                 preds_sorted_item_scores, preds_sorted_item_ids = torch.topk(
-                    preds, k=self.args.predict_top_k, dim=-1
+                    pred_next_item, k=self.args.predict_top_k, dim=-1
                 )
                 self._maybe_log_predictions(
                     labels,
@@ -526,18 +534,25 @@ class Trainer(BaseTrainer):
                 )
                 # The output predictions will be a tuple with the ranked top-n item ids,
                 # and item recommendation scores
-                preds_item_ids_scores = (
-                    preds_sorted_item_ids,
-                    preds_sorted_item_scores,
-                )
-                preds_item_ids_scores_host = (
-                    preds_item_ids_scores
-                    if preds_item_ids_scores_host is None
-                    else nested_concat(
-                        preds_item_ids_scores_host,
-                        preds_item_ids_scores,
+                if isinstance(preds, dict):
+                    preds["next-item"] = (
+                        preds_sorted_item_ids,
+                        preds_sorted_item_scores,
                     )
+                else:
+                    preds = (
+                        preds_sorted_item_ids,
+                        preds_sorted_item_scores,
+                    )
+
+            preds_host = (
+                preds
+                if preds_host is None
+                else nested_concat(
+                    preds_host,
+                    preds,
                 )
+            )
 
             self.control = self.callback_handler.on_prediction_step(
                 self.args, self.state, self.control
@@ -563,19 +578,19 @@ class Trainer(BaseTrainer):
                         if all_labels is None
                         else nested_concat(all_labels, labels, padding_index=0)
                     )
-                if preds_item_ids_scores_host is not None:
-                    preds_item_ids_scores = nested_numpify(preds_item_ids_scores_host)
-                    all_preds_item_ids_scores = (
-                        preds_item_ids_scores
-                        if all_preds_item_ids_scores is None
+                if preds_host is not None:
+                    preds = nested_numpify(preds_host)
+                    all_preds = (
+                        preds
+                        if all_preds is None
                         else nested_concat(
-                            all_preds_item_ids_scores,
-                            preds_item_ids_scores,
+                            all_preds,
+                            preds,
                         )
                     )
 
                 # Set back to None to begin a new accumulation
-                losses_host, preds_item_ids_scores_host, labels_host = None, None, None
+                losses_host, preds_host, labels_host = None, None, None
 
         if self.args.past_index and hasattr(self, "_past"):
             # Clean the state at the end of the evaluation loop
@@ -592,14 +607,14 @@ class Trainer(BaseTrainer):
             all_labels = (
                 labels if all_labels is None else nested_concat(all_labels, labels, padding_index=0)
             )
-        if preds_item_ids_scores_host is not None:
-            preds_item_ids_scores = nested_numpify(preds_item_ids_scores_host)
-            all_preds_item_ids_scores = (
-                preds_item_ids_scores
-                if all_preds_item_ids_scores is None
+        if preds_host is not None:
+            preds_host = nested_numpify(preds_host)
+            all_preds = (
+                preds_host
+                if all_preds is None
                 else nested_concat(
-                    all_preds_item_ids_scores,
-                    preds_item_ids_scores,
+                    all_preds,
+                    preds_host,
                 )
             )
         # Get Number of samples :
@@ -611,8 +626,8 @@ class Trainer(BaseTrainer):
         # samplers has been rounded to a multiple of batch_size, so we truncate.
         if all_losses is not None:
             all_losses = all_losses[:num_samples]
-        if all_preds_item_ids_scores is not None:
-            all_preds_item_ids_scores = nested_truncate(all_preds_item_ids_scores, num_samples)
+        if all_preds is not None:
+            all_preds = nested_truncate(all_preds, num_samples)
         if all_labels is not None:
             all_labels = nested_truncate(all_labels, num_samples)
 
@@ -631,7 +646,7 @@ class Trainer(BaseTrainer):
             metrics[f"{metric_key_prefix}_/loss"] = all_losses.mean().item()
 
         return EvalLoopOutput(
-            predictions=all_preds_item_ids_scores,
+            predictions=all_preds,
             label_ids=all_labels,
             metrics=metrics,
             num_samples=num_examples,

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -511,14 +511,16 @@ class Trainer(BaseTrainer):
             if preds is not None and self.args.predict_top_k > 0:
                 # get outputs of next-item scores
                 if isinstance(preds, dict):
-                    assert (
-                        "next-item" in preds
-                    ), "Top-k prediction is specific to NextItemPredictionTask"
+                    assert any(
+                        isinstance(x, NextItemPredictionTask) for x in model.prediction_tasks
+                    ), "Top-k prediction is specific to NextItemPredictionTask, "
+                    "Please ensure `self.args.predict_top_k == 0` "
                     pred_next_item = preds["next-item"]
                 else:
                     assert isinstance(
                         model.prediction_tasks[0], NextItemPredictionTask
-                    ), "Top-k prediction is specific to NextItemPredictionTask"
+                    ), "Top-k prediction is specific to NextItemPredictionTask, "
+                    "Please ensure `self.args.predict_top_k == 0` "
                     pred_next_item = preds
 
                 preds_sorted_item_scores, preds_sorted_item_ids = torch.topk(


### PR DESCRIPTION
Fixes #636

### Goals :soccer:
- Fix the predictions returned by `Trainer.predict()`.
- Ensure `predict_top_k` can only be applied to NextItemPredictionTask. 
- Fix the output shapes of the model's predictions in the sequential binary classification or the regression task.

### Implementation Details :construction:


### Testing Details :mag:
- Add `test_sequential_binary_classification_model` to test a sequential model trained with a per-item binary classification task. 
- Checks the shapes of predictions in `test_trainer_music_streaming`
- Add `test_trainer_trop_k_with_wrong_task` to ensure the BC task cannot be used with `predict_top_k > 0`