### PR TITLE
fix model output_schema dims for BC/Regression task case 

### DIFF
--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -36,7 +36,7 @@ from merlin_standard_lib import Schema
 from ..block.base import BlockBase, BlockOrModule, BlockType
 from ..features.base import InputBlock
 from ..features.sequence import TabularFeaturesType
-from ..typing import TabularData
+from ..typing import TabularData, TensorOrTabularData
 from ..utils.torch_utils import LossMixin, MetricsMixin
 
 
@@ -46,7 +46,6 @@ def name_fn(name, inp):
 
 class PredictionTask(torch.nn.Module, LossMixin, MetricsMixin):
     """Individual prediction-task of a model.
-
     Parameters
     ----------
     loss: torch.nn.Module
@@ -109,7 +108,6 @@ class PredictionTask(torch.nn.Module, LossMixin, MetricsMixin):
         """
         The method will be called when block is converted to a model,
         i.e when linked to prediction head.
-
         Parameters
         ----------
         block:
@@ -224,7 +222,6 @@ class PredictionTask(torch.nn.Module, LossMixin, MetricsMixin):
 
 class Head(torch.nn.Module, LossMixin, MetricsMixin):
     """Head of a Model, a head has a single body but could have multiple prediction-tasks.
-
     Parameters
     ----------
     body: Block
@@ -269,7 +266,6 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
 
     def build(self, inputs=None, device=None, task_blocks=None):
         """Build each prediction task that's part of the head.
-
         Parameters
         ----------
         body
@@ -306,7 +302,6 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
         inputs: Optional[TabularFeaturesType] = None,
     ) -> "Head":
         """Instantiate a Head from a Schema through tagged targets.
-
         Parameters
         ----------
         schema: DatasetSchema
@@ -316,7 +311,6 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
         task_weight_dict
         loss_reduction
         inputs
-
         Returns
         -------
         Head
@@ -348,12 +342,10 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
 
     def pop_labels(self, inputs: TabularData) -> TabularData:
         """Pop the labels from the different prediction_tasks from the inputs.
-
         Parameters
         ----------
         inputs: TabularData
             Input dictionary containing all targets.
-
         Returns
         -------
         TabularData
@@ -413,7 +405,6 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
         targets: Union[torch.Tensor, TabularData],
     ) -> Dict[str, Union[Dict[str, torch.Tensor], torch.Tensor]]:
         """Calculate metrics of the task(s) set in the Head instance.
-
         Parameters
         ----------
         predictions: Union[torch.Tensor, TabularData]
@@ -468,7 +459,6 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
 
     def to_model(self, **kwargs) -> "Model":
         """Convert the head to a Model.
-
         Returns
         -------
         Model
@@ -487,7 +477,6 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
         name: str = None,
     ):
         """Model class that can aggregate one or multiple heads.
-
         Parameters
         ----------
         head: Head
@@ -517,7 +506,9 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
         self.head_reduction = head_reduction
         self.optimizer = optimizer
 
-    def forward(self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs):
+    def forward(
+        self, inputs: TensorOrTabularData, targets=None, training=False, testing=False, **kwargs
+    ):
         # Convert inputs to float32 which is the default type, expected by PyTorch
         for name, val in inputs.items():
             if torch.is_floating_point(val):
@@ -578,7 +569,6 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
         targets: Union[torch.Tensor, TabularData],
     ) -> Dict[str, Union[Dict[str, torch.Tensor], torch.Tensor]]:
         """Calculate metrics of the task(s) set in the Head instance.
-
         Parameters
         ----------
         predictions: Union[torch.Tensor, TabularData]
@@ -783,13 +773,8 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
 
         return Core_Schema(output_cols)
 
-    @property
-    def prediction_tasks(self):
-        return [task for head in self.heads for task in list(head.prediction_task_dict.values())]
-
     def save(self, path: Union[str, os.PathLike], model_name="t4rec_model_class"):
         """Saves the model to f"{export_path}/{model_name}.pkl" using `cloudpickle`
-
         Parameters
         ----------
         path : Union[str, os.PathLike]
@@ -814,7 +799,6 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
     @classmethod
     def load(cls, path: Union[str, os.PathLike], model_name="t4rec_model_class") -> "Model":
         """Loads a T4Rec model that was saved with `model.save()`.
-
         Parameters
         ----------
         path : Union[str, os.PathLike]


### PR DESCRIPTION
This PR fixes the dims info in the `output_schema` based on the task and `summary_type`. The current dims for the BC task is not accurately set.

Better to merge this after this PR https://github.com/NVIDIA-Merlin/Transformers4Rec/pull/641