### PR TITLE
Set device in dataloaders

### DIFF
--- a/examples/end-to-end-session-based/03-Session-based-Yoochoose-multigpu-training-PyT.ipynb
+++ b/examples/end-to-end-session-based/03-Session-based-Yoochoose-multigpu-training-PyT.ipynb
@@ -172,12 +172,12 @@
     "            max_sequence_length=20,\n",
     "            data_loader_engine='merlin',\n",
     "            num_train_epochs=10, \n",
-    "            dataloader_drop_last=False,\n",
+    "            dataloader_drop_last=True,\n",
     "            per_device_train_batch_size = sh_args.per_device_train_batch_size,\n",
     "            per_device_eval_batch_size = sh_args.per_device_eval_batch_size,\n",
     "            learning_rate=sh_args.learning_rate,\n",
     "            report_to = [],\n",
-    "            logging_steps=200\n",
+    "            logging_steps=200,\n",
     "        )\n",
     "\n",
     "# Instantiate the trainer\n",
@@ -204,7 +204,6 @@
     "    time_index_eval = time_index + 1\n",
     "    train_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_train}/train.parquet\"))\n",
     "    eval_paths = glob.glob(os.path.join(OUTPUT_DIR, f\"{time_index_eval}/valid.parquet\"))\n",
-    "    print(train_paths)\n",
     "    \n",
     "    # Train on day related to time_index \n",
     "    print('*'*20)\n",
@@ -215,7 +214,7 @@
     "    recsys_trainer.train()\n",
     "    recsys_trainer.state.global_step +=1\n",
     "    print('finished')\n",
-    "    \n",
+    "\n",
     "    # Evaluate on the following day\n",
     "    recsys_trainer.eval_dataset_or_path = eval_paths\n",
     "    train_metrics = recsys_trainer.evaluate(metric_key_prefix='eval')\n",
@@ -227,7 +226,7 @@
     "    wipe_memory()\n",
     "\n",
     "end = time.time()\n",
-    "print('Total training time:',end-start)\n"
+    "print('Total training time:',end-start)"
    ]
   },
   {
@@ -259,7 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m torch.distributed.launch --nproc_per_node 2 pyt_trainer.py --path \"/workspace/data/preproc_sessions_by_day\" --learning-rate 0.0005"
+    "! torchrun --nproc_per_node 2 pyt_trainer.py --path \"/workspace/data/preproc_sessions_by_day\" --learning-rate 0.0005"
    ]
   },
   {


### PR DESCRIPTION
Fixes #651 

### Goals :soccer:
Fix multi-gpu training notebook.

### Implementation Details :construction:
- Depends on https://github.com/NVIDIA-Merlin/dataloader/pull/113.
- `device` is set identical to `local_rank`.
- Without dropping the last batch (`dataloader_drop_last=True`), `recsys_trainer.evaluate` hangs. Probably need to investigate this because this didn't happen before the list column refactoring in merlin-dataloader (see ticket).
- `torch.distributed.launch ` is replaced with `torchrun` because the former has been deprecated.

### Testing Details :mag:
Manually tested in `nvcr.io/nvidia/merlin/merlin-pytorch:23.02` by installing the main branch of all Merlin libraries via `pip install . --no-deps`. Run 01 notebook first and then run 03 notebook.
