### PR TITLE
Add workflow to check if base branch of pull request is development

### DIFF
--- a/.github/workflows/base-branch-check.yml
+++ b/.github/workflows/base-branch-check.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   check:
-    uses: NVIDIA-Merlin/.github/.github/workflows/check-base-branch.yml@check-base-ref
+    uses: NVIDIA-Merlin/.github/.github/workflows/check-base-branch.yml@main

--- a/.github/workflows/base-branch-check.yml
+++ b/.github/workflows/base-branch-check.yml
@@ -1,0 +1,9 @@
+name: Require Development Base Branch
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  check:
+    uses: NVIDIA-Merlin/.github/.github/workflows/check-base-branch.yml@check-base-ref


### PR DESCRIPTION
<!--

Thank you for contributing to Transformers4Rec :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Part of https://github.com/NVIDIA-Merlin/Merlin/issues/866

Adding a check to ensure we create pull requests into the development branch of the repo.

If you create a pull request into a branch that is not the development branch, you'll receive something like the following error:

```
Error: Pull Request base ref must be the development branch: 'main'. Found base ref: 'release-23.02' .
If you're sure you need to merge this change into 'release-23.02' instead. 
You can add the label 'skip-base-branch-check'. 
```