### PR TITLE
Remove torch.squeeze() step from the model's forward method. 

### DIFF
--- a/tests/unit/torch/model/test_model.py
+++ b/tests/unit/torch/model/test_model.py
@@ -83,6 +83,12 @@ def test_sequential_prediction_model(
     assert len(list(output["predictions"])) == 2
     assert set(list(output.keys())) == set(["loss", "labels", "predictions"])
 
+    # test inference inputs with only one item
+    inference_inputs = tr.data.tabular_sequence_testing_data.torch_synthetic_data(
+        num_rows=10, min_session_length=1, max_session_length=1
+    )
+    _ = model(inference_inputs)
+
 
 def test_sequential_binary_classification_model(
     torch_yoochoose_tabular_transformer_features,

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -387,8 +387,7 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
                 else:
                     label = targets
                 if label is not None:
-                    # Remove dimension `1` as merlin dataloader returns tensors of shape (-1, 1)
-                    label = torch.squeeze(label.float(), -1)
+                    label = label.float()
                 task_output = task(
                     body_outputs, targets=label, training=training, testing=testing, **kwargs
                 )
@@ -518,9 +517,6 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
         for name, val in inputs.items():
             if torch.is_floating_point(val):
                 inputs[name] = val.to(torch.float32)
-        # Squeeze second dimension `1` of non-list inputs
-        for name, val in inputs.items():
-            inputs[name] = torch.squeeze(val, -1)
 
         if isinstance(targets, dict) and len(targets) == 0:
             # `pyarrow`` dataloader is returning {} instead of None


### PR DESCRIPTION
- The new data loader is now returning scalar inputs as a 1-D tensor instead of a 2-D so the `torch.squeeze()` op inside the model's forward method is no longer needed.
- This `torch.squeeze()` op was also raising an issue at inference when we pass a sequence with one element only. In fact, by calling `torch.squeeze()` on all inputs we lose the information to separate between scalar features and list features with only one element. The new data loader is ensuring that list input with one element are kept as 2-D.
- I removed the `torch.squeeze()` op and added a check for applying the model on input sequences with one element, at inference.
