### PR TITLE
Add support for ragged inputs to model

### DIFF
--- a/tests/unit/torch/model/test_model.py
+++ b/tests/unit/torch/model/test_model.py
@@ -76,11 +76,12 @@ def test_sequential_prediction_model_with_ragged_inputs(torch_yoochoose_like, yo
         num_rows=10, min_session_length=1, max_session_length=4, ragged=True
     )
     inference_inputs_2 = tr.data.tabular_sequence_testing_data.torch_synthetic_data(
-        num_rows=10, min_session_length=1, max_session_length=10, ragged=True
+        num_rows=20, min_session_length=1, max_session_length=10, ragged=True
     )
     model_output = model(inference_inputs)
 
-    # if model is traced with ragged inputs it must be called with ragged inputs
+    # if the model is traced with ragged inputs it can only be called with ragged inputs
+    # if the model is traced with padded inputs it can only be called with padded inputs
     traced_model = torch.jit.trace(model, inference_inputs, strict=False)
     traced_model_output = traced_model(inference_inputs)
     assert torch.equal(model_output, traced_model_output)

--- a/tests/unit/utils/test_padding.py
+++ b/tests/unit/utils/test_padding.py
@@ -17,7 +17,7 @@ from itertools import accumulate
 
 import torch
 
-from transformers4rec.torch.utils.padding import pad_batch
+from transformers4rec.torch.utils.padding import pad_batch, pad_inputs
 
 
 def _get_values_offsets(data):
@@ -30,81 +30,127 @@ def _get_values_offsets(data):
     return torch.tensor(values), torch.tensor(offsets)
 
 
-def test_pad_values_offsets_dict():
-    data = [[1, 2], [], [3, 4, 5]]
-    values, offsets = _get_values_offsets(data)
+class TestPadBatch:
+    def test_pad_values_offsets(self):
+        data = [[1, 2], [], [3, 4, 5]]
+        values, offsets = _get_values_offsets(data)
 
-    x = {"a__values": values, "a__offsets": offsets}
+        x = {"a__values": values, "a__offsets": offsets}
 
-    padded_x = pad_batch(x, {"a": 7})
-    assert torch.equal(
-        padded_x["a"],
-        torch.tensor(
-            [
-                [1, 2, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [3, 4, 5, 0, 0, 0, 0],
-            ]
-        ),
-    )
+        padded_x = pad_batch(x, {"a": 7})
+        assert torch.equal(
+            padded_x["a"],
+            torch.tensor(
+                [
+                    [1, 2, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [3, 4, 5, 0, 0, 0, 0],
+                ]
+            ),
+        )
+
+    def test_with_truncation(self):
+        data = [[1, 2], [], [3, 4, 5, 4, 7]]
+        values, offsets = _get_values_offsets(data)
+
+        x = {
+            "a__values": values,
+            "a__offsets": offsets,
+            "b": torch.tensor([[1, 2, 3, 4], [6, 7, 8, 9]]),
+        }
+
+        padded_x = pad_batch(x, {"a": 3, "b": 2})
+        assert torch.equal(
+            padded_x["a"],
+            torch.tensor(
+                [
+                    [1, 2, 0],
+                    [0, 0, 0],
+                    [3, 4, 5],
+                ]
+            ),
+        )
+        assert torch.equal(
+            padded_x["b"],
+            torch.tensor(
+                [
+                    [1, 2],
+                    [6, 7],
+                ]
+            ),
+        )
+
+    def test_ragged_and_dense(self):
+        data = [[1, 2], [], [3, 4, 5]]
+        values, offsets = _get_values_offsets(data)
+
+        x = {
+            "a__values": values,
+            "a__offsets": offsets,
+            "b": torch.tensor([[3, 6], [4, 1], [8, 4]]),
+        }
+
+        padded_x = pad_batch(x, {"a": 7, "b": 3})
+        assert torch.equal(
+            padded_x["a"],
+            torch.tensor(
+                [
+                    [1, 2, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [3, 4, 5, 0, 0, 0, 0],
+                ]
+            ),
+        )
+        assert torch.equal(
+            padded_x["b"],
+            torch.tensor(
+                [
+                    [3, 6, 0],
+                    [4, 1, 0],
+                    [8, 4, 0],
+                ]
+            ),
+        )
 
 
-def test_pad_with_truncation():
-    data = [[1, 2], [], [3, 4, 5, 4, 7]]
-    values, offsets = _get_values_offsets(data)
+class TestPadInputs:
+    def test_ragged_inputs(self):
+        data = [[1, 2, 3, 4, 5], [6, 7, 8]]
+        values, offsets = _get_values_offsets(data)
 
-    x = {
-        "a__values": values,
-        "a__offsets": offsets,
-        "b": torch.tensor([[1, 2, 3, 4], [6, 7, 8, 9]]),
-    }
+        inputs = {"a__values": values, "a__offsets": offsets}
+        padded_inputs = pad_inputs(inputs)
+        assert torch.equal(
+            padded_inputs["a"],
+            torch.tensor(
+                [
+                    [1, 2, 3, 4, 5],
+                    [6, 7, 8, 0, 0],
+                ]
+            ),
+        )
 
-    padded_x = pad_batch(x, {"a": 3, "b": 2})
-    assert torch.equal(
-        padded_x["a"],
-        torch.tensor(
-            [
-                [1, 2, 0],
-                [0, 0, 0],
-                [3, 4, 5],
-            ]
-        ),
-    )
-    assert torch.equal(
-        padded_x["b"],
-        torch.tensor(
-            [
-                [1, 2],
-                [6, 7],
-            ]
-        ),
-    )
+    def test_with_max_sequence_length(self):
+        data = [[1, 2, 3, 4, 5], [6, 7, 8, 9]]
+        values, offsets = _get_values_offsets(data)
 
-
-def test_pad_values_dense():
-    data = [[1, 2], [], [3, 4, 5]]
-    values, offsets = _get_values_offsets(data)
-
-    x = {"a__values": values, "a__offsets": offsets, "b": torch.tensor([[3, 6], [4, 1], [8, 4]])}
-
-    padded_x = pad_batch(x, {"a": 7, "b": 3})
-    assert torch.equal(
-        padded_x["a"],
-        torch.tensor(
-            [
-                [1, 2, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0],
-                [3, 4, 5, 0, 0, 0, 0],
-            ]
-        ),
-    )
-    assert torch.equal(
-        padded_x["b"],
-        torch.tensor(
-            [
-                [3, 6, 0],
-                [4, 1, 0],
-                [8, 4, 0],
-            ]
-        ),
-    )
+        inputs = {"a__values": values, "a__offsets": offsets, "b": torch.tensor([[3, 6], [4, 1]])}
+        padded_inputs = pad_inputs(inputs, max_sequence_length=3)
+        assert torch.equal(
+            padded_inputs["a"],
+            torch.tensor(
+                [
+                    [1, 2, 3],
+                    [6, 7, 8],
+                ]
+            ),
+        )
+        assert torch.equal(
+            padded_inputs["b"],
+            torch.tensor(
+                [
+                    [3, 6],
+                    [4, 1],
+                ]
+            ),
+        )

--- a/tests/unit/utils/test_padding.py
+++ b/tests/unit/utils/test_padding.py
@@ -147,10 +147,5 @@ class TestPadInputs:
         )
         assert torch.equal(
             padded_inputs["b"],
-            torch.tensor(
-                [
-                    [3, 6],
-                    [4, 1],
-                ]
-            ),
+            inputs["b"],
         )

--- a/tests/unit/utils/test_padding.py
+++ b/tests/unit/utils/test_padding.py
@@ -30,25 +30,6 @@ def _get_values_offsets(data):
     return torch.tensor(values), torch.tensor(offsets)
 
 
-def test_pad_values_offsets_tuple():
-    data = [[1, 2], [], [3, 4, 5]]
-    values, offsets = _get_values_offsets(data)
-
-    x = {"a": (values, offsets)}
-
-    padded_x = pad_batch(x, {"a": 5})
-    assert torch.equal(
-        padded_x["a"],
-        torch.tensor(
-            [
-                [1, 2, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-                [3, 4, 5, 0, 0],
-            ]
-        ),
-    )
-
-
 def test_pad_values_offsets_dict():
     data = [[1, 2], [], [3, 4, 5]]
     values, offsets = _get_values_offsets(data)

--- a/tests/unit/utils/test_padding.py
+++ b/tests/unit/utils/test_padding.py
@@ -68,6 +68,38 @@ def test_pad_values_offsets_dict():
     )
 
 
+def test_pad_with_truncation():
+    data = [[1, 2], [], [3, 4, 5, 4, 7]]
+    values, offsets = _get_values_offsets(data)
+
+    x = {
+        "a__values": values,
+        "a__offsets": offsets,
+        "b": torch.tensor([[1, 2, 3, 4], [6, 7, 8, 9]]),
+    }
+
+    padded_x = pad_batch(x, {"a": 3, "b": 2})
+    assert torch.equal(
+        padded_x["a"],
+        torch.tensor(
+            [
+                [1, 2, 0],
+                [0, 0, 0],
+                [3, 4, 5],
+            ]
+        ),
+    )
+    assert torch.equal(
+        padded_x["b"],
+        torch.tensor(
+            [
+                [1, 2],
+                [6, 7],
+            ]
+        ),
+    )
+
+
 def test_pad_values_dense():
     data = [[1, 2], [], [3, 4, 5]]
     values, offsets = _get_values_offsets(data)

--- a/transformers4rec/data/dataset.py
+++ b/transformers4rec/data/dataset.py
@@ -41,7 +41,7 @@ class Dataset:
         return TensorflowMetadata.from_json(self.schema.to_json()).to_merlin_schema()
 
     def torch_synthetic_data(
-        self, num_rows=100, min_session_length=5, max_session_length=20, device=None
+        self, num_rows=100, min_session_length=5, max_session_length=20, device=None, ragged=False
     ):
         from transformers4rec.torch.utils import schema_utils
 
@@ -51,6 +51,7 @@ class Dataset:
             min_session_length=min_session_length,
             max_session_length=max_session_length,
             device=device,
+            ragged=ragged,
         )
 
     def tf_synthetic_data(self, num_rows=100, min_session_length=5, max_session_length=20):

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -545,7 +545,7 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
             padding_lengths = {}
             for name in inputs.keys():
                 if name.endswith("__offsets"):
-                    padding_lengths[name[:-len("__offsets")]] = padding_sequence_length
+                    padding_lengths[name[: -len("__offsets")]] = padding_sequence_length
             if padding_lengths:
                 inputs = pad_batch(inputs, padding_lengths)
 

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -545,7 +545,7 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
             padding_lengths = {}
             for name in inputs.keys():
                 if name.endswith("__offsets"):
-                    padding_lengths[name[:-9]] = padding_sequence_length
+                    padding_lengths[name[:-len("__offsets")]] = padding_sequence_length
             if padding_lengths:
                 inputs = pad_batch(inputs, padding_lengths)
 

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -37,7 +37,7 @@ from ..block.base import BlockBase, BlockOrModule, BlockType
 from ..features.base import InputBlock
 from ..features.sequence import TabularFeaturesType
 from ..typing import TabularData
-from ..utils.padding import pad_batch
+from ..utils.padding import pad_inputs
 from ..utils.torch_utils import LossMixin, MetricsMixin
 
 
@@ -472,43 +472,6 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
         """
 
         return Model(self, **kwargs)
-
-
-@torch.jit.script
-def pad_inputs(inputs: Dict[str, torch.Tensor], max_sequence_length: Optional[int]):
-    """Pad ragged inputs to dense tensors with max sequence length
-
-    Parameters
-    ----------
-    inputs : Dict[str, Tensor]
-        Dictionary of tensors
-
-    Returns
-    -------
-    inputs : Dict[str, Tensor]
-        Padded inputs
-    """
-    batch_max_sequence_length = 0
-    for key, val in inputs.items():
-        if key.endswith("__offsets"):
-            offsets = val
-            max_row_length = int(torch.max(offsets[1:] - offsets[:-1]))
-            batch_max_sequence_length = max(max_row_length, batch_max_sequence_length)
-
-    padding_sequence_length = batch_max_sequence_length
-    if max_sequence_length is not None:
-        padding_sequence_length = min(max_sequence_length, batch_max_sequence_length)
-
-    if padding_sequence_length > 0:
-        padding_lengths: Dict[str, int] = {}
-        for key in inputs.keys():
-            if key.endswith("__offsets"):
-                col_name: str = key[: -len("__offsets")]
-                padding_lengths[col_name] = padding_sequence_length
-        if padding_lengths:
-            inputs = pad_batch(inputs, padding_lengths)
-
-    return inputs
 
 
 class Model(torch.nn.Module, LossMixin, MetricsMixin):

--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -372,7 +372,10 @@ class MerlinDataLoader(T4RecDataLoader, DLDataLoader):
     def _get_pad_fn(padding_lengths):
         def pad_fn(x, y):
             new_x = pad_batch(x, padding_lengths)
-            new_y = pad_batch(y, padding_lengths)
+            if y is not None and isinstance(y, dict):
+                new_y = pad_batch(y, padding_lengths)
+            else:
+                new_y = y
             return new_x, new_y
 
         return pad_fn

--- a/transformers4rec/torch/utils/padding.py
+++ b/transformers4rec/torch/utils/padding.py
@@ -47,11 +47,12 @@ def _pad_ragged_tensor(values, offsets, padding_length):
     offsets = _squeeze(offsets)
     num_rows = len(offsets) - 1
     diff_offsets = offsets[1:] - offsets[:-1]
+    max_length = int(diff_offsets.max())
     indices = _get_indices(offsets, diff_offsets)
     sparse_tensor = torch.sparse_coo_tensor(
-        indices.T, values, torch.Size([num_rows, padding_length]), device=values.device
+        indices.T, values, torch.Size([num_rows, max_length]), device=values.device
     )
-    return sparse_tensor.to_dense()
+    return _pad_dense_tensor(sparse_tensor.to_dense(), padding_length)
 
 
 Batch = Dict[str, Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]

--- a/transformers4rec/torch/utils/padding.py
+++ b/transformers4rec/torch/utils/padding.py
@@ -109,13 +109,18 @@ def pad_batch(
 
 
 @torch.jit.script
-def pad_inputs(inputs: Dict[str, torch.Tensor], max_sequence_length: Optional[int]):
-    """Pad ragged inputs to dense tensors with max sequence length
+def pad_inputs(inputs: Dict[str, torch.Tensor], max_sequence_length: Optional[int] = None):
+    """Pad ragged inputs to fixed size tensors.
+
+    Pads all the sequence features in the inputs to the same length.
+    The minimum of max_sequence_length and the maximum sequence length in the inputs.
 
     Parameters
     ----------
     inputs : Dict[str, Tensor]
         Dictionary of tensors
+    max_sequence_length: int, optional
+        The maximum sequence length to limit sequence features to
 
     Returns
     -------


### PR DESCRIPTION
<!--

Thank you for contributing to Transformers4Rec :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Part of https://github.com/NVIDIA-Merlin/Merlin/issues/255

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

- Enable Transformers4Rec model to be called with ragged input representation.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Adds pre-processing step to the first part of the forward method of the model that pads any tensors in the ragged representation.
  - Where there are two tensors with names `{feature}__values` `{feature}__offests`.
  - Pads all to minimum of the maximum sequence in batch or the model max_sequence_length (if defined)

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

- Adds a test for model with sequence inputs and passing ragged representation inputs