### PR TITLE
Implemented sampled softmax for NextItemPredictionTask

### DIFF
--- a/examples/t4rec_paper_experiments/t4r_paper_repro/transf_exp_args.py
+++ b/examples/t4rec_paper_experiments/t4r_paper_repro/transf_exp_args.py
@@ -441,6 +441,21 @@ class ModelArguments:
         },
     )
 
+    # Sampled Softmax
+    sampled_softmax: Optional[bool] = field(
+        default=False,
+        metadata={"help": "Enables sampled softmax for training."},
+    )
+
+    sampled_softmax_max_n_samples: Optional[int] = field(
+        default=1000,
+        metadata={
+            "help": "Max number of unique negative samples for sampled softmax."
+            "The number of samples might differ across batches, as the exact number "
+            "of unique items might not be the same."
+        },
+    )
+
 
 @dataclass
 class TrainingArguments(T4RecTrainingArguments):

--- a/examples/t4rec_paper_experiments/t4r_paper_repro/transf_exp_main.py
+++ b/examples/t4rec_paper_experiments/t4r_paper_repro/transf_exp_main.py
@@ -145,6 +145,8 @@ def main():
         softmax_temperature=model_args.softmax_temperature,
         metrics=metrics,
         loss=label_smoothing_xe_loss,
+        sampled_softmax=model_args.sampled_softmax,
+        max_n_samples=model_args.sampled_softmax_max_n_samples,
     )
 
     model_config = get_model_config(training_args, model_args)

--- a/tests/unit/torch/_conftest.py
+++ b/tests/unit/torch/_conftest.py
@@ -88,7 +88,7 @@ def torch_ranking_metrics_inputs():
     VOCAB_SIZE = 40
     features = {}
     features["scores"] = torch.tensor(np.random.uniform(0, 1, (POS_EXAMPLE, VOCAB_SIZE)))
-    features["ks"] = torch.LongTensor([1, 2, 3, 5, 10, 20])
+    features["ks"] = [1, 2, 3, 5, 10, 20]
     features["labels_one_hot"] = torch.LongTensor(
         np.random.choice(a=[0, 1], size=(POS_EXAMPLE, VOCAB_SIZE))
     )

--- a/tests/unit/torch/model/test_model.py
+++ b/tests/unit/torch/model/test_model.py
@@ -374,6 +374,21 @@ def test_with_d_model_different_from_item_dim(torch_yoochoose_like, yoochoose_sc
     assert model(torch_yoochoose_like, training=True)
 
 
+def test_with_next_item_pred_sampled_softmax(torch_yoochoose_like, yoochoose_schema):
+    d_model = 32
+    transformer_config = tconf.XLNetConfig.build(d_model, 4, 2, 20)
+    input_module = tr.TabularSequenceFeatures.from_schema(
+        yoochoose_schema,
+        max_sequence_length=20,
+        continuous_projection=64,
+        d_output=32,
+        masking="mlm",
+    )
+    task = tr.NextItemPredictionTask(weight_tying=True, sampled_softmax=True, max_n_samples=1000)
+    model = transformer_config.to_torch_model(input_module, task)
+    assert model(torch_yoochoose_like, training=True)
+
+
 @pytest.mark.parametrize("masking", ["causal", "mlm", "plm", "rtd"])
 def test_output_shape_mode_eval(torch_yoochoose_like, yoochoose_schema, masking):
     input_module = tr.TabularSequenceFeatures.from_schema(

--- a/tests/unit/torch/test_losses.py
+++ b/tests/unit/torch/test_losses.py
@@ -25,10 +25,8 @@ def test_item_prediction_with_label_smoothing_ce_loss(
 
     loss = head_output["loss"]
 
-    n_classes = 51997
     head_predictions = head_output["predictions"]["next-item"]
-    manuall_loss = torch.nn.NLLLoss(reduction="mean")
-    target_with_smoothing = labels_all * (1 - label_smoothing) + label_smoothing / n_classes
-    manual_output_loss = manuall_loss(head_predictions, target_with_smoothing.to(torch.long))
+    manuall_loss = torch.nn.CrossEntropyLoss(reduction="mean", label_smoothing=label_smoothing)
+    manual_output_loss = manuall_loss(head_predictions, labels_all)
 
     assert np.allclose(manual_output_loss.detach().numpy(), loss.detach().numpy(), rtol=1e-3)

--- a/tests/unit/torch/test_torchscript.py
+++ b/tests/unit/torch/test_torchscript.py
@@ -24,6 +24,5 @@ def test_torchsciprt_not_strict(torch_yoochoose_like, yoochoose_schema):
     traced_model = torch.jit.trace(model, torch_yoochoose_like, strict=False)
     assert isinstance(traced_model, torch.jit.TopLevelTracedModule)
     assert torch.allclose(
-        model(torch_yoochoose_like),
-        traced_model(torch_yoochoose_like),
+        model(torch_yoochoose_like), traced_model(torch_yoochoose_like), rtol=5e-02
     )

--- a/tests/unit/torch/test_torchscript.py
+++ b/tests/unit/torch/test_torchscript.py
@@ -24,5 +24,5 @@ def test_torchsciprt_not_strict(torch_yoochoose_like, yoochoose_schema):
     traced_model = torch.jit.trace(model, torch_yoochoose_like, strict=False)
     assert isinstance(traced_model, torch.jit.TopLevelTracedModule)
     assert torch.allclose(
-        model(torch_yoochoose_like), traced_model(torch_yoochoose_like), rtol=5e-02
+        model(torch_yoochoose_like), traced_model(torch_yoochoose_like), rtol=1e-02
     )

--- a/transformers4rec/torch/block/base.py
+++ b/transformers4rec/torch/block/base.py
@@ -60,8 +60,8 @@ class Block(BlockBase):
         self.module = module
         self._output_size = output_size
 
-    def forward(self, inputs):
-        return self.module(inputs)
+    def forward(self, inputs, **kwargs):
+        return self.module(inputs, **kwargs)
 
     def forward_output_size(self, input_size):
         if self._output_size[0] is None:

--- a/transformers4rec/torch/losses.py
+++ b/transformers4rec/torch/losses.py
@@ -1,16 +1,15 @@
 import torch
-from torch.nn.modules.loss import _WeightedLoss
 
 
-class LabelSmoothCrossEntropyLoss(_WeightedLoss):
-    """Constructor for cross-entropy loss with label smoothing
+def LabelSmoothCrossEntropyLoss(smoothing: float = 0.0, reduction: str = "mean", **kwargs):
+    """Coss-entropy loss with label smoothing.
+    This is going to be deprecated. You should use torch.nn.CrossEntropyLoss()
+    directly that in recent PyTorch versions already supports label_smoothing arg
 
     Parameters
     ----------
     smoothing: float
         The label smoothing factor. Specify a value between 0 and 1.
-    weight: torch.Tensor
-        The tensor of weights given to each class.
     reduction: str
         Specifies the reduction to apply to the output.
         Specify one of `none`, `sum`, or `mean`.
@@ -18,43 +17,4 @@ class LabelSmoothCrossEntropyLoss(_WeightedLoss):
     Adapted from https://github.com/NingAnMe/Label-Smoothing-for-CrossEntropyLoss-PyTorch
     """
 
-    def __init__(self, weight: torch.Tensor = None, reduction: str = "mean", smoothing=0.0):
-        super().__init__(weight=weight, reduction=reduction)
-        self.smoothing = smoothing
-        self.weight = weight
-        self.reduction = reduction
-
-    @staticmethod
-    def _smooth_one_hot(targets: torch.Tensor, n_classes: int, smoothing: float = 0.0):
-        assert 0 <= smoothing < 1, f"smoothing factor {smoothing} should be between 0 and 1"
-        with torch.no_grad():
-            targets = (
-                torch.empty(size=(targets.size(0), n_classes), device=targets.device)
-                .fill_(smoothing / (n_classes - 1))
-                .scatter_(1, targets.data.unsqueeze(1).to(torch.int64), 1.0 - smoothing)
-            )
-        return targets
-
-    def forward(self, inputs, targets):
-        targets = LabelSmoothCrossEntropyLoss._smooth_one_hot(
-            targets, inputs.size(-1), self.smoothing
-        )
-        lsm = inputs
-
-        if self.weight is not None:
-            lsm = lsm * self.weight.unsqueeze(0)
-
-        loss = -(targets * lsm).sum(-1)
-
-        if self.reduction == "sum":
-            loss = loss.sum()
-        elif self.reduction == "mean":
-            loss = loss.mean()
-        elif self.reduction == "none":
-            loss = loss
-        else:
-            raise ValueError(
-                f"{self.reduction} is not supported, please choose one of the following values"
-                " [`sum`, `none`, `mean`]"
-            )
-        return loss
+    return torch.nn.CrossEntropyLoss(label_smoothing=smoothing, reduction=reduction, **kwargs)

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -325,7 +325,7 @@ class NextItemPredictionTask(PredictionTask):
             loss = self.loss(x, y)
             return {
                 "loss": loss,
-                "labels": labels_all,
+                "labels": y,
                 "predictions": x,
             }
         else:

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -531,7 +531,7 @@ class _NextItemPredictionTask(torch.nn.Module):
         return "NextItemPredictionTask"
 
 
-class LogUniformSampler(object):
+class LogUniformSampler:
     def __init__(
         self,
         max_n_samples: int,

--- a/transformers4rec/torch/ranking_metric.py
+++ b/transformers4rec/torch/ranking_metric.py
@@ -173,7 +173,7 @@ class AvgPrecisionAt(RankingMetric):
         num_relevant = torch.sum(labels, dim=1)
         max_k = max(ks)
 
-        precisions = self.precision_at(1 + torch.arange(max_k), topk_scores, topk_labels)
+        precisions = self.precision_at(list(range(1, max_k + 1)), topk_scores, topk_labels)
         rel_precisions = precisions * topk_labels
 
         for index, k in enumerate(ks):

--- a/transformers4rec/torch/ranking_metric.py
+++ b/transformers4rec/torch/ranking_metric.py
@@ -50,7 +50,7 @@ class RankingMetric(tm.Metric):
         # Computing the metrics at different cut-offs
         if self.labels_onehot:
             target = torch_utils.tranform_label_to_onehot(target, preds.size(-1))
-        metric = self._metric(torch.LongTensor(self.top_ks), preds.view(-1, preds.size(-1)), target)
+        metric = self._metric(self.top_ks, preds.view(-1, preds.size(-1)), target)
         self.metric_mean.append(metric)  # type: ignore
 
     def compute(self):
@@ -171,7 +171,7 @@ class AvgPrecisionAt(RankingMetric):
 
         # Compute average precisions at K
         num_relevant = torch.sum(labels, dim=1)
-        max_k = ks.max().item()
+        max_k = max(ks)
 
         precisions = self.precision_at(1 + torch.arange(max_k), topk_scores, topk_labels)
         rel_precisions = precisions * topk_labels
@@ -214,9 +214,7 @@ class DCGAt(RankingMetric):
         dcgs = torch_utils.create_output_placeholder(scores, ks)
 
         # Compute discounts
-        discount_positions = torch.arange(ks.max().item()).to(
-            device=scores.device, dtype=torch.float32
-        )
+        discount_positions = torch.arange(max(ks)).to(device=scores.device, dtype=torch.float32)
 
         discount_log_base = torch.log(
             torch.Tensor([log_base]).to(device=scores.device, dtype=torch.float32)

--- a/transformers4rec/torch/utils/torch_utils.py
+++ b/transformers4rec/torch/utils/torch_utils.py
@@ -189,8 +189,8 @@ def calculate_batch_size_from_input_size(input_size):
 
 
 def check_inputs(ks, scores, labels):
-    if len(ks.shape) > 1:
-        raise ValueError("ks should be a 1-dimensional tensor")
+    if not (isinstance(ks, (list, tuple)) and len(ks) >= 1):
+        raise ValueError("ks should be a list or tuple with at least one element")
 
     if len(scores.shape) != 2:
         raise ValueError("scores must be a 2-dimensional tensor")
@@ -202,9 +202,9 @@ def check_inputs(ks, scores, labels):
         raise ValueError("scores and labels must be the same shape")
 
     return (
-        ks.to(dtype=torch.int32, device=scores.device),
+        ks,
         scores,
-        labels,  # .to(dtype=torch.float32, device=scores.device),
+        labels,
     )
 
 


### PR DESCRIPTION
### Goals :soccer:
Implements sampled softmax for NextItemPredictionTask. It allows for faster training and evaluation.

### Implementation Details :construction:
- Refactored `NextItemPredictionTask` to have a standard output layer op (a dot product) when `weight_tying` is both enabled or not.
- Added `sampled_softmax` option to `NextItemPredictionTask`
```python
tr.NextItemPredictionTask(weight_tying=True, sampled_softmax=True, max_n_samples=1000)
```
- Implemented a `LogUniformSampler` that is able to return probabilities for both unique_sampling = True or False
- Implemented a generic logQ correction for `NextItemPredictionTask`
- Changed `LabelSmoothCrossEntropyLoss` to be just an alias of `torch.nn.CrossEntropyLoss(label_smoothing=...)`, as PyTorch has added `label_smoothing` in one of its last versions. Added a `DeprecationWarning` to ``LabelSmoothCrossEntropyLoss``

### Testing Details :mag:
- Created a test to check and demonstrate the usage of sampled softmax: `test_with_next_item_pred_sampled_softmax`

### Benchmark :mag:
I have performed a benchmark of sampled softmax in different configurations (weight tying enabled and disabled and with different # samples) to understand the impact of sampled softmax in training throughtput and accuracy. 

#### Setup
The experiments were performed using the [T4Rec paper reproducibility script](https://github.com/NVIDIA-Merlin/Transformers4Rec/tree/main/examples/t4rec_paper_experiments), which was changed to accept new CLI args `--sampled_softmax` and `--sampled_softmax_max_n_samples`, and the [REES46 preprocessed dataset](https://drive.google.com/file/d/1BvCHc4eXComuNK93bKhRM6cbg9y5p350/view?usp=share_link).

The benchmark was done using [Merlin PyTorch 23.02 container](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/merlin/containers/merlin-pytorch), with manual update of the `core`, `dataloader` and `models` folders to pull and install their latest version from GitHub.

**Command line**
The script performs incremental training and evaluation. I use the first five days for training and evaluation is computed for each next day. Here is the base command line with the utilized hparams.
The hparams that are changed for the experiments are `--mf_constrained_embeddings` (enables weight-tying if provided, i.e., reusing the item id embedding table as output layer), `--sampled_softmax` (enables sampled softmax if provided) and `--sampled_softmax_max_n_samples` (number of negative samples).

```bash
cd /transformers4rec/examples/t4rec_paper_experiments/t4r_paper_repro
CUDA_VISIBLE_DEVICES=0 python3 transf_exp_main.py --output_dir ./tmp/ --overwrite_output_dir --do_train --do_eval --validate_every 10 --logging_steps 20 --save_steps 0 --data_path $DATA_PATH --features_schema_path "../datasets_configs/ecom_rees46/rees46_schema.pbtxt" --fp16 --data_loader_engine merlin --start_time_window_index 1 --final_time_window_index 6 --time_window_folder_pad_digits 4 --model_type albert --loss_type cross_entropy --per_device_eval_batch_size 128 --similarity_type concat_mlp --tf_out_activation tanh --inp_merge mlp --learning_rate_warmup_steps 0 --learning_rate_schedule linear_with_warmup --hidden_act gelu --num_train_epochs 5 --dataloader_drop_last --compute_metrics_each_n_steps 1 --session_seq_length_max 20 --eval_on_last_item_seq_only  --layer_norm_featurewise --mlm --num_hidden_groups -1 --inner_group_num 1 --per_device_train_batch_size 512 --learning_rate 0.0004904752786458524 --dropout 0.0 --input_dropout 0.1 --weight_decay 9.565968888623912e-05 --d_model 320 --item_embedding_dim 320 --n_layer 2 --n_head 8  --stochastic_shared_embeddings_replacement_prob 0.06 --item_id_embeddings_init_std 0.11 --other_embeddings_init_std 0.025 --mlm_probability 0.6000000000000001 --eval_on_test_set --seed 100 --report_to none --label_smoothing 0.2 --mf_constrained_embeddings --sampled_softmax --sampled_softmax_max_n_samples 1000
```

#### Results
The results can be seen in the following table. Steps/sec represents the throughtput and Recall and NDCG are accuracy top-k metrics.

![bechmark_sampled_softmax](https://user-images.githubusercontent.com/504752/231885367-dab9c31b-823b-4fcf-bf10-eecf96081d33.png)

**The gist is that it is possible to get both a better training throughput with a gain of accuracy by using sampled softmax.**

Some notes from this results:
- Throughput (steps/sec) always increase with sampled sofmax and smaller number of examples, as expected.
- The best accuracies was obtained with sampled softmax for both weight-tying False and True.  **But the best overall accuracy obtained with weight tying=True, sampled softmax and logQ correction**
- There are specific lines in the results table where we report results without logQ correction proposed for sampled softmax. It is noticeable that without it the sampled softmax underperforms in terms of accuracy, as it overpenalizes popular items, that are sampled more often as negatives.
- A side note is that weight-tying typically provides better accuracy when enabled, as we previously observed reported in our RecSys competition papers and in [T4Rec paper](https://github.com/NVIDIA-Merlin/publications/tree/main/2021_acm_recsys_transformers4rec).

_Disclaimer_: These experiments were not hypertuned for every configuration. Furthermore, accuracy results might differ a lot with different runs in particular when smaller number of samples (e.g. 1k) are used.