### PR TITLE
Add topk arg to return topk items and scores at inference step

### DIFF
--- a/tests/integration/notebooks/test_getting_started_session_based.py
+++ b/tests/integration/notebooks/test_getting_started_session_based.py
@@ -16,6 +16,7 @@ pytest.importorskip("transformers")
 def test_func():
     with testbook(
         REPO_ROOT / "examples" / "getting-started-session-based" / "01-ETL-with-NVTabular.ipynb",
+        timeout=180,
         execute=False,
     ) as tb1:
         tb1.inject(
@@ -35,6 +36,7 @@ def test_func():
         / "examples"
         / "getting-started-session-based"
         / "02-session-based-XLNet-with-PyT.ipynb",
+        timeout=180,
         execute=False,
     ) as tb2:
         tb2.inject(
@@ -68,6 +70,7 @@ def test_func():
         / "examples"
         / "getting-started-session-based"
         / "03-serving-session-based-model-torch-backend.ipynb",
+        timeout=720,
         execute=False,
     ) as tb3:
         tb3.inject(

--- a/tests/unit/torch/test_torchscript_with_topk.py
+++ b/tests/unit/torch/test_torchscript_with_topk.py
@@ -1,0 +1,32 @@
+import torch
+
+import transformers4rec.torch as tr
+from transformers4rec.config import transformer as tconf
+
+
+def test_torchscript_with_topk(torch_yoochoose_like, yoochoose_schema):
+    input_module = tr.TabularSequenceFeatures.from_schema(
+        yoochoose_schema,
+        max_sequence_length=20,
+        d_output=64,
+        masking="causal",
+    )
+    prediction_task = tr.NextItemPredictionTask(weight_tying=True)
+    transformer_config = tconf.XLNetConfig.build(
+        d_model=64, n_head=8, n_layer=2, total_seq_length=20
+    )
+    model = transformer_config.to_torch_model(input_module, prediction_task)
+
+    _ = model(torch_yoochoose_like, training=False)
+
+    topk = 10
+    model.top_k = topk
+    model.eval()
+
+    traced_model = torch.jit.trace(model, torch_yoochoose_like, strict=False)
+
+    assert isinstance(traced_model, torch.jit.TopLevelTracedModule)
+    assert torch.allclose(
+        model(torch_yoochoose_like)[0], traced_model(torch_yoochoose_like)[0], rtol=1e-02
+    )
+    assert traced_model(torch_yoochoose_like)[0].shape[1] == topk

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -371,7 +371,7 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
         testing: bool = False,
         targets: Union[torch.Tensor, TabularData] = None,
         call_body: bool = False,
-        top_k: Optional[int] = -1,
+        top_k: Optional[int] = None,
         **kwargs,
     ) -> Union[torch.Tensor, TabularData]:
         outputs = {}
@@ -497,7 +497,7 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
         optimizer: Type[torch.optim.Optimizer] = torch.optim.Adam,
         name: str = None,
         max_sequence_length: Optional[int] = None,
-        top_k: Optional[int] = -1,
+        top_k: Optional[int] = None,
     ):
         """Model class that can aggregate one or multiple heads.
         Parameters
@@ -517,7 +517,7 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
             Used to truncate sequence inputs longer than this value.
         top_k: int, optional
             The number of items to return at the inference step once the model is deployed.
-            Default is -1, which will return all items.
+            Default is None, which will return all items.
         """
         if head_weights:
             if not isinstance(head_weights, list):
@@ -804,7 +804,7 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                     "int_domain": int_domain,
                 }
                 # in case one sets top_k at the inference step we return two outputs
-                if self.top_k > 0:
+                if self.top_k:
                     # be sure categ item-id dtype in model.input schema and output schema matches
                     col_name = self.input_schema.select_by_tag(Tags.ITEM_ID).column_names[0]
                     col_dtype = (

--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -798,8 +798,15 @@ class Model(torch.nn.Module, LossMixin, MetricsMixin):
                 properties = {
                     "int_domain": int_domain,
                 }
-                col_schema = ColumnSchema(name, dtype=np.float32, properties=properties, dims=dims)
-                output_cols.append(col_schema)
+                # in case one sets top_k at the inference step we return two outputs
+                if self.top_k > 0:
+                    col_schema_scores = ColumnSchema("item_id_scores", dtype=np.float32, properties=properties, dims=dims)
+                    col_schema_ids = ColumnSchema("item_ids", dtype=np.int64, properties=properties, dims=dims)
+                    output_cols.append(col_schema_scores)
+                    output_cols.append(col_schema_ids)
+                else:
+                    col_schema = ColumnSchema(name, dtype=np.float32, properties=properties, dims=dims)
+                    output_cols.append(col_schema)
 
         return Core_Schema(output_cols)
 

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -304,7 +304,13 @@ class NextItemPredictionTask(PredictionTask):
         )
 
     def forward(
-        self, inputs: torch.Tensor, targets=None, training=False, testing=False, top_k=None, **kwargs
+        self,
+        inputs: torch.Tensor,
+        targets=None,
+        training=False,
+        testing=False,
+        top_k=None,
+        **kwargs,
     ):
         if isinstance(inputs, (tuple, list)):
             inputs = inputs[0]
@@ -344,7 +350,7 @@ class NextItemPredictionTask(PredictionTask):
             # Compute predictions probs
             x, _ = self.pre(x)  # type: ignore
 
-            if top_k == None:
+            if top_k is None:
                 return x
             else:
                 preds_sorted_item_scores, preds_sorted_item_ids = torch.topk(x, k=top_k, dim=-1)

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -303,7 +303,9 @@ class NextItemPredictionTask(PredictionTask):
             body, input_size, device=device, inputs=inputs, task_block=task_block, pre=pre
         )
 
-    def forward(self, inputs: torch.Tensor, targets=None, training=False, testing=False, top_k=-1, **kwargs):
+    def forward(
+        self, inputs: torch.Tensor, targets=None, training=False, testing=False, top_k=-1, **kwargs
+    ):
         if isinstance(inputs, (tuple, list)):
             inputs = inputs[0]
         x = inputs.float()

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -303,7 +303,7 @@ class NextItemPredictionTask(PredictionTask):
             body, input_size, device=device, inputs=inputs, task_block=task_block, pre=pre
         )
 
-    def forward(self, inputs: torch.Tensor, targets=None, training=False, testing=False, **kwargs):
+    def forward(self, inputs: torch.Tensor, targets=None, training=False, testing=False, top_k=-1, **kwargs):
         if isinstance(inputs, (tuple, list)):
             inputs = inputs[0]
         x = inputs.float()
@@ -342,7 +342,11 @@ class NextItemPredictionTask(PredictionTask):
             # Compute predictions probs
             x, _ = self.pre(x)  # type: ignore
 
-            return x
+            if top_k == -1:
+                return x
+            else:
+                preds_sorted_item_scores, preds_sorted_item_ids = torch.topk(x, k=top_k, dim=-1)
+                return preds_sorted_item_ids
 
     def remove_pad_3d(self, inp_tensor, non_pad_mask):
         # inp_tensor: (n_batch x seqlen x emb_dim)

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -304,7 +304,7 @@ class NextItemPredictionTask(PredictionTask):
         )
 
     def forward(
-        self, inputs: torch.Tensor, targets=None, training=False, testing=False, top_k=-1, **kwargs
+        self, inputs: torch.Tensor, targets=None, training=False, testing=False, top_k=None, **kwargs
     ):
         if isinstance(inputs, (tuple, list)):
             inputs = inputs[0]
@@ -344,7 +344,7 @@ class NextItemPredictionTask(PredictionTask):
             # Compute predictions probs
             x, _ = self.pre(x)  # type: ignore
 
-            if top_k == -1:
+            if top_k == None:
                 return x
             else:
                 preds_sorted_item_scores, preds_sorted_item_ids = torch.topk(x, k=top_k, dim=-1)

--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -348,7 +348,7 @@ class NextItemPredictionTask(PredictionTask):
                 return x
             else:
                 preds_sorted_item_scores, preds_sorted_item_ids = torch.topk(x, k=top_k, dim=-1)
-                return preds_sorted_item_ids
+                return preds_sorted_item_scores, preds_sorted_item_ids
 
     def remove_pad_3d(self, inp_tensor, non_pad_mask):
         # inp_tensor: (n_batch x seqlen x emb_dim)

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -529,6 +529,10 @@ class Trainer(BaseTrainer):
                     else nested_concat(labels_host, labels, padding_index=0)
                 )
             if preds is not None and self.args.predict_top_k > 0:
+                if self.model.top_k != -1:
+                     raise ValueError("you cannot set top_k argument in the model class and the, " 
+                                      "predict_top_k  in the trainer at the same time. Please ensure setting "
+                                      "only predict_top_k")
                 # get outputs of next-item scores
                 if isinstance(preds, dict):
                     assert any(

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -530,9 +530,11 @@ class Trainer(BaseTrainer):
                 )
             if preds is not None and self.args.predict_top_k > 0:
                 if self.model.top_k != -1:
-                     raise ValueError("you cannot set top_k argument in the model class and the, " 
-                                      "predict_top_k  in the trainer at the same time. Please ensure setting "
-                                      "only predict_top_k")
+                    raise ValueError(
+                        "you cannot set top_k argument in the model class and the, "
+                        "predict_top_k  in the trainer at the same time. Please ensure setting "
+                        "only predict_top_k"
+                    )
                 # get outputs of next-item scores
                 if isinstance(preds, dict):
                     assert any(

--- a/transformers4rec/torch/trainer.py
+++ b/transformers4rec/torch/trainer.py
@@ -529,7 +529,7 @@ class Trainer(BaseTrainer):
                     else nested_concat(labels_host, labels, padding_index=0)
                 )
             if preds is not None and self.args.predict_top_k > 0:
-                if self.model.top_k != -1:
+                if self.model.top_k:
                     raise ValueError(
                         "you cannot set top_k argument in the model class and the, "
                         "predict_top_k  in the trainer at the same time. Please ensure setting "


### PR DESCRIPTION
This PR adds functionality for returning topk most relevant (with the highest scores) item ids from Triton IS, for NextItemPrediction task.

Current blocker:

~~The code designed to return top_k item ids (int 64 dtype), but model.output_schema returns `next_item` as float32 dtype, which creates an error from Triton.~~

Shall we change the code base in a way that model.output_schema matches with the expected output and output dtype from Triton? Or shall we return top_k item id scores, instead of item_ids?

**Status update:**

After modifying the model.output_schema, we can now return two outputs (item_scores, item_ids) from Triton.

Remaining tasks:
- [x] be sure the dtype of categorical item-id in the model.output schema matches with the model.input_schema
- [x] add a unit test
- [x] add an example notebook to showcase topK layer or modify one of the existing example: will be taken care of by this PR https://github.com/NVIDIA-Merlin/Transformers4Rec/pull/680