### PR TITLE
Use `torch.testing.assert_close` to check model outputs

### DIFF
--- a/tests/unit/torch/model/test_model.py
+++ b/tests/unit/torch/model/test_model.py
@@ -84,11 +84,11 @@ def test_sequential_prediction_model_with_ragged_inputs(torch_yoochoose_like, yo
     # if the model is traced with padded inputs it can only be called with padded inputs
     traced_model = torch.jit.trace(model, inference_inputs, strict=False)
     traced_model_output = traced_model(inference_inputs)
-    assert torch.equal(model_output, traced_model_output)
+    torch.testing.assert_close(model_output, traced_model_output)
 
     model_output = model(inference_inputs_2)
     traced_model_output = traced_model(inference_inputs_2)
-    assert torch.equal(model_output, traced_model_output)
+    torch.testing.assert_close(model_output, traced_model_output)
 
 
 @pytest.mark.parametrize("task", [tr.BinaryClassificationTask, tr.RegressionTask])


### PR DESCRIPTION
<!--

Thank you for contributing to Transformers4Rec :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes random error in `test_sequential_prediction_model_with_ragged_inputs` due to slightly different output values.

Use `torch.testing.assert_close` to check model outputs in `test_sequential_prediction_model_with_ragged_inputs`