### PR TITLE
Fixing the projection layer when using weight tying and dim from Transformer output and item embedding differs

### DIFF
--- a/transformers4rec/torch/model/prediction_task.py
+++ b/transformers4rec/torch/model/prediction_task.py
@@ -281,7 +281,7 @@ class NextItemPredictionTask(PredictionTask):
                     f"to be equal to the item-id embedding dimension '{item_dim}'"
                 )
                 # project input tensors to same dimension as item-id embeddings
-                task_block = MLPBlock([item_dim])
+                task_block = MLPBlock([item_dim], activation=None)
 
         # Retrieve the masking from the input block
         self.masking = inputs.masking


### PR DESCRIPTION
Fixes the projection when using weight tying, as it should not use an activation function, as found by @bschifferer 