### PR TITLE
don't re-run github actions when PRs  get closed

### DIFF
--- a/.github/workflows/gpu-ci-integration.yml
+++ b/.github/workflows/gpu-ci-integration.yml
@@ -8,7 +8,7 @@ on:
       - v*
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 jobs:
   gpu-ci:

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -8,7 +8,7 @@ on:
       - v*
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Github Actions have been being double-executed when a PR gets merged - the second because the PR is `closed`. We don't need to run it then.

We've had similar PRs in other repos and I'll continue going through the rest.