### PR TITLE
Update tag pattern in GitHub Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
     tags:
-      - v*
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     branches: [main]
 

--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     tags:
-      - v*
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gpu-ci-integration.yml
+++ b/.github/workflows/gpu-ci-integration.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
     tags:
-      - v*
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ main ]
     tags:
-      - v*
+      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened]

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -4,7 +4,7 @@ on:
   push:
     # trigger on tags only
     tags:
-      - v*
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Part of https://github.com/NVIDIA-Merlin/Merlin/issues/961

Update pattern used to match tags when running workflows. From `v*` to  `v[0-9]+.[0-9]+.[0-9]+`

This pattern ensures we only run these workflows with the tags corresponding to a release (e.g. `v23.04.00`. Ignoring other tags like a dev tag `v23.05.dev0`)