### PR TITLE
[DRAFT] Remove the custom padding in T4Rec's MerlinDataLoader

### DIFF
--- a/tests/unit/torch/test_trainer.py
+++ b/tests/unit/torch/test_trainer.py
@@ -600,7 +600,7 @@ def test_trainer_trop_k_with_wrong_task():
     assert "Top-k prediction is specific to NextItemPredictionTask" in str(excinfo.value)
 
 
-def test_trainer_trop_k_with_padding_in_dataloader():
+def test_trainer_with_padding_in_dataloader():
     from merlin.dataloader.ops.padding import Padding
     from merlin.io import Dataset
     from merlin.schema.tags import Tags


### PR DESCRIPTION
### Goals :soccer:
The Merlin data loader has a Padding operator that we can pass via the transforms parameter. To avoid code redundancy, I created a PR in T4Rec that removes custom padding from the T4Rec's `MerlinDataLoader` class. 
In this PR, the default behavior of the Trainer is to set the data loader without padding. If the user wants to perform padding outside of the model, they can explicitly provide a data loader with a Padding transform.

### Implementation Details :construction:
- Removes the `sparse_max` logic from `MerlinDataLoader`
- Extend `MerlinDataLoader` to accept the `transforms` parameter where the user can pass the Padding op. 

### Testing Details :mag:
- Add a unit test to check that we can provide a data loader with Padding op to the Trainer class
