### PR TITLE
Pin the HuggingFace version as latest release is breaking T4Rec

### DIFF
--- a/requirements/base_external.txt
+++ b/requirements/base_external.txt
@@ -1,3 +1,3 @@
-transformers>=4.12,<5
+transformers>=4.12,<4.28
 tqdm>=4.27
 pyarrow>=1.0


### PR DESCRIPTION
The recent release 4.29.0 of HuggingFace (released yesterday) is breaking T4Rec tests with the following error: 

``` ImportError(
                "Using the `Trainer` with `PyTorch` requires `accelerate`: Run `pip install --upgrade accelerate`"
            )
```

The current T4Rec is not making use of `accelarate`, so this PR suggests pinning the version to <4.28