### PR TITLE
Add Transformers Torch Extras to install requirements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Those components can be installed as optional arguments for the `pip install` co
 To install Transformers4Rec using Pip, run the following command:
 
 ```shell
-pip install transformers4rec[pytorch,nvtabular]
+pip install transformers4rec[nvtabular]
 ```
 
 -> Be aware that installing Transformers4Rec with `pip` does not automatically install RAPIDS cuDF.

--- a/requirements/base_external.txt
+++ b/requirements/base_external.txt
@@ -1,3 +1,4 @@
-transformers>=4.12,<5
+transformers[torch]>=4.12,<5
 tqdm>=4.27
 pyarrow>=1.0
+torchmetrics>=0.10.0


### PR DESCRIPTION
<!--

Thank you for contributing to Transformers4Rec :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Adds `torch` extra from `transformers` package to base requirements. 

This results in moving the torch dependency from an optional depdendency to an install depdendency. Since Transformers4Rec is only implemented for Torch and won't work without it, this seems ok and simplifies the pip install for the package.

We'll also pickup any depdendencies added to the torch extras in `transformers` like the [recently added `accelerate` dependency](https://github.com/huggingface/transformers/pull/22752).
