### PR TITLE
Remove deps from integration test env

### DIFF
--- a/requirements/base_external.txt
+++ b/requirements/base_external.txt
@@ -1,4 +1,2 @@
-transformers[torch]>=4.12,<5
 tqdm>=4.27
 pyarrow>=1.0
-torchmetrics>=0.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -56,8 +56,6 @@ sitepackages=true
 setenv = 
     TF_GPU_ALLOCATOR=cuda_malloc_async
     LD_LIBRARY_PATH=/opt/tritonserver/backends/pytorch
-deps =
-    -rrequirements/test.txt   
 commands =
     ; install latest Merlin libraries from source
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}


### PR DESCRIPTION
<!--

Thank you for contributing to Transformers4Rec :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Remove deps from integration test env

Checking if this makes any difference to the CUDA version error we're  seeing