### PR TITLE
Fix the CLM performance mismatch between evaluation and manual inference

### DIFF
--- a/tests/unit/torch/features/test_sequential.py
+++ b/tests/unit/torch/features/test_sequential.py
@@ -136,7 +136,6 @@ def test_sequential_tabular_features_ignore_masking(schema, torch_yoochoose_like
         input_module(torch_yoochoose_like, training=False, testing=True).detach().cpu().numpy()
     )
 
-    assert np.allclose(output_wo_masking, output_inference_masking, rtol=1e-04, atol=1e-08)
     assert not np.allclose(output_wo_masking, output_clm_masking, rtol=1e-04, atol=1e-08)
 
     input_module._masking = MaskedLanguageModeling(hidden_size=100)

--- a/tests/unit/torch/test_masking.py
+++ b/tests/unit/torch/test_masking.py
@@ -43,7 +43,7 @@ def test_mask_only_last_item_for_eval(torch_masking_inputs, task):
     lm = tr.masking.masking_registry[task](
         hidden_dim, padding_idx=torch_masking_inputs["padding_idx"]
     )
-    lm.compute_masked_targets(torch_masking_inputs["labels"], training=False)
+    lm.compute_masked_targets(torch_masking_inputs["labels"], training=False, testing=True)
     # get non padded last items
     non_padded_mask = torch_masking_inputs["labels"] != torch_masking_inputs["padding_idx"]
     rows_ids = torch.arange(
@@ -57,7 +57,7 @@ def test_mask_only_last_item_for_eval(torch_masking_inputs, task):
     trgt_pad = lm.masked_targets != torch_masking_inputs["padding_idx"]
     out_last = lm.masked_targets[trgt_pad].flatten().numpy()
     # check that only one item is masked for each session
-    assert lm.mask_schema.sum() == torch_masking_inputs["input_tensor"].size(0)
+    assert trgt_pad.sum() == torch_masking_inputs["input_tensor"].size(0)
     # check only the last non-paded item is masked
     assert all(last_labels == out_last)
 
@@ -109,7 +109,7 @@ def test_clm_training_on_last_item(torch_masking_inputs):
     # last labels from output
     trgt_pad = lm.masked_targets != torch_masking_inputs["padding_idx"]
     out_last = lm.masked_targets[trgt_pad].flatten().numpy()
-    assert lm.mask_schema.sum() == torch_masking_inputs["input_tensor"].size(0)
+    assert trgt_pad.sum() == torch_masking_inputs["input_tensor"].size(0)
     assert all(last_labels == out_last)
 
 


### PR DESCRIPTION
Fixes #719 

### Goals :soccer:
The current CLM strategy is as follows 
![image](https://github.com/NVIDIA-Merlin/Transformers4Rec/assets/17721108/76406b3b-2bcf-4eaf-80c4-7abf17be16f4)
The main issues of the current implementation are: 
- We mask useful past information when we evaluate on the last item only ==> This is wrong as past information is a valuable context for predictions. 
- At inference, the padded positions are represented with `0`-embeddings while during training these positions are replaced with trainable [MASK] embeddings. ==> We should have the same training, evaluation, and inference representation strategy. 

### Implementation Details :construction:
- Updated the class `CausalLanguageModeling` to: 
    -  Replace padded positions with [MASK] embeddings at inference. 
    - During the evaluation of the last item, I defined the `label_mask` as the padding mask information (to keep information about actual past items). 

- I ran the `t4r_paper_repro` script using 5 days of ecomrees46 dataset and these are the results: 
```
**CLM run using main branch (w/o fix)**
Recall@10 of manually masked test data = 0.3915199603272998
eval//next-item/recall_at_10 0.25108

**Fix the evaluation on last item by not masking the past information**
eval_/next-item/recall_at_10 = 0.2980385422706604
Recall@10 of manually masked test data = 0.29812381188527975
```


### Testing Details :mag:
- Changed `test_mask_only_last_item_for_eval` to get target mask information from `lm.masked_targets` 
- Changed `test_sequential_tabular_features_ignore_masking` as the inference mode of CLM is changing the inputs by replacing `0` padded positions with  [MASK] embeddings

## Future work 
- The [MASK] embeddings is not used to generate the next-item prediction scores and this raises a question about whether we should remove it and just use `0`-embedding to represent padded positions. 
==> We need to re-run T4Rec paper experiments without [MASK] variable and check how the evaluation results are impacted. 