### PR TITLE
Fix recall metric calculation

### DIFF
--- a/transformers4rec/torch/ranking_metric.py
+++ b/transformers4rec/torch/ranking_metric.py
@@ -131,7 +131,7 @@ class RecallAt(RankingMetric):
 
         # Compute recalls at K
         num_relevant = torch.sum(labels, dim=-1)
-        rel_indices = (num_relevant != 0).nonzero().squeeze()
+        rel_indices = (num_relevant != 0).nonzero().squeeze(dim=1)
         rel_count = num_relevant[rel_indices]
 
         if rel_indices.shape[0] > 0:


### PR DESCRIPTION
<!--

Thank you for contributing to Transformers4Rec :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
- Fix recall metric error when batch size is 1


### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/23d5e3ba73b3d490400e45bf4feba94ed473432f/transformers4rec/torch/ranking_metric.py#L134
The squeeze() function removes all dimensions when batch size is 1.
I've added `dim=1` argument to keep dimension along batch.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Test code for error reproduction
```
import torch
from transformers4rec.torch import ranking_metric

ks = [1, 2]
scores = torch.tensor( [ [1,2,3], ])
labels = torch.tensor( [ [0,1,0], ])
ranking_metric.RecallAt()._metric(ks, scores, labels)
```
Error message
```
    135 rel_indices = (num_relevant != 0).nonzero().squeeze()
    136 rel_count = num_relevant[rel_indices]
--> 138 if rel_indices.shape[0] > 0:
    139     for index, k in enumerate(ks):
    140         rel_labels = topk_labels[rel_indices, : int(k)]

IndexError: tuple index out of range
```