### PR TITLE
Fix TypeError in Head.build when body lacks output_size

### DIFF
--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -285,7 +285,7 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
         device
         task_blocks
         """
-        if not getattr(self.body, "output_size", None)():
+        if not getattr(self.body, "output_size", lambda: None)():
             raise ValueError(
                 "Can't infer output-size of the body, please provide  "
                 "a `Block` with a output-size. You can wrap any torch.Module in a Block."


### PR DESCRIPTION
### Goals :soccer:

Restore the descriptive `ValueError("Can't infer output-size of the body ...")` that was inadvertently shadowed in PR #802 by a `TypeError: 'NoneType' object is not callable`.

Fixes #811.

### Implementation Details :construction:

`transformers4rec/torch/model/base.py:288` uses a callable sentinel so that a body without an `output_size` method falls through to the `raise ValueError(...)` branch:

```python
if not getattr(self.body, "output_size", None)():
    raise ValueError(
        "Can't infer output-size of the body, please provide  "
        "a `Block` with a output-size. You can wrap any torch.Module in a Block."
    )
```

The previous sentinel was `lambda: None` (a callable that returns a falsy value). PR #802 (`ab7207cf`, "Sec pic fix") replaced the sentinel with `None`. `None()` is not callable — it raises `TypeError` *before* the `not` is evaluated — so users who hit this path get a confusing `'NoneType' object is not callable` instead of the documented "Can't infer output-size of the body" guidance.

Minimal fix — restore the callable sentinel:

```diff
-if not getattr(self.body, "output_size", None)():
+if not getattr(self.body, "output_size", lambda: None)():
```

The semantics are byte-for-byte identical to the pre-#802 code. This is the smallest change that preserves the original intent without touching PR #802's other security improvements.

### Testing Details :mag:

Pre-fix behavior (reproduces the regression):
```python
class Body: ...
getattr(Body(), "output_size", None)()
# TypeError: 'NoneType' object is not callable
```

Post-fix behavior:
```python
getattr(Body(), "output_size", lambda: None)()
# None   (falsy; falls through to raise ValueError(...) in Head.build)
```

No new unit test is added: every existing body fixture in `tests/` provides `output_size`, so there is no negative case to regression-test without introducing a new stub. Happy to add one if reviewers prefer — a `torch.nn.Module`-only body (without the `output_size` method that `Block` exposes) is the natural shape.