### PR TITLE
Normalize `lists` argument in MerlinDataLoader._augment_schema

### DIFF
--- a/transformers4rec/torch/utils/data_utils.py
+++ b/transformers4rec/torch/utils/data_utils.py
@@ -398,6 +398,7 @@ class MerlinDataLoader(T4RecDataLoader, DLDataLoader):
         cats = cats or []
         conts = conts or []
         labels = labels or []
+        lists = lists or []
 
         schema = schema.select_by_name(conts + cats + labels + lists)
 


### PR DESCRIPTION
### Goals :soccer:

Stop `MerlinDataLoader._augment_schema` from raising `TypeError` when the caller omits `lists=` (the common case for datasets without list-typed features).

Fixes #812.

### Implementation Details :construction:

`transformers4rec/torch/utils/data_utils.py` normalizes `cats`, `conts`, and `labels` to empty lists when they default to `None`, but the normalization for `lists` was missing:

```python
cats = cats or []
conts = conts or []
labels = labels or []
# missing: lists = lists or []

schema = schema.select_by_name(conts + cats + labels + lists)
```

Any caller that does not pass `lists=` (or passes `lists=None` explicitly) hits `TypeError: can only concatenate list (not "NoneType") to list` at the `select_by_name` line. The later `for col in lists:` loop would also raise `TypeError: 'NoneType' object is not iterable`.

Minimal fix — add the symmetric `lists = lists or []` alongside the other three:

```diff
         cats = cats or []
         conts = conts or []
         labels = labels or []
+        lists = lists or []

         schema = schema.select_by_name(conts + cats + labels + lists)
```

### Testing Details :mag:

Pre-fix repro (extracted from the source, no install needed):

```python
class Schema:
    def select_by_name(self, cols):
        return self

def _augment_schema(schema, cats=None, conts=None, labels=None, lists=None):
    cats = cats or []
    conts = conts or []
    labels = labels or []
    return schema.select_by_name(conts + cats + labels + lists)

_augment_schema(Schema(), cats=["x"])
# TypeError: can only concatenate list (not "NoneType") to list
```

With the patch, the same call succeeds.

No unit test is added — `_augment_schema` is currently exercised indirectly by every `MerlinDataLoader` construction in the test suite that supplies `lists=[...]`. I am happy to add a direct test for `lists=None` if reviewers would prefer.