### PR TITLE
Restore default factory on `Head._task_weights`

### DIFF
--- a/transformers4rec/torch/model/base.py
+++ b/transformers4rec/torch/model/base.py
@@ -269,7 +269,7 @@ class Head(torch.nn.Module, LossMixin, MetricsMixin):
             for i, task in enumerate(prediction_tasks):
                 self.prediction_task_dict[task.task_name] = task
 
-        self._task_weights = defaultdict()
+        self._task_weights = defaultdict(lambda: 1.0)
         if task_weights:
             for task, val in zip(cast(List[PredictionTask], prediction_tasks), task_weights):
                 self._task_weights[task.task_name] = val


### PR DESCRIPTION
### Goals :soccer:

Restore the documented "unset task weight defaults to 1.0" behavior that regressed in PR #802.

Fixes #813.

### Implementation Details :construction:

PR #802 (`ab7207cf`) changed `self._task_weights = defaultdict(lambda: 1.0)` to `self._task_weights = defaultdict()` in `transformers4rec/torch/model/base.py:272`. A `defaultdict` constructed with no factory has the same runtime behavior as a plain `dict` — missing keys raise `KeyError`. The previous factory returned `1.0` for unset task weights, which matches the docstring for `Head(task_weights=...)`:

> `task_weights`: optional per-task loss weight. Missing entries default to 1.0.

One usage inside `Head.forward` was patched to `.get(name, 1.0)` as a workaround, but any other indexing site — internal future code or external subclasses that read `head._task_weights[task_name]` — now raises `KeyError` where it previously returned `1.0`.

Minimal fix — restore the factory:

```diff
-self._task_weights = defaultdict()
+self._task_weights = defaultdict(lambda: 1.0)
```

This is the smallest change that re-establishes the `defaultdict` contract and avoids the need for scattered `.get(name, 1.0)` work-arounds.

### Testing Details :mag:

Pre-fix regression:
```python
>>> from collections import defaultdict
>>> d = defaultdict()
>>> d["anything"]
KeyError: 'anything'
```

Post-fix:
```python
>>> d = defaultdict(lambda: 1.0)
>>> d["anything"]
1.0
```

Existing tests that touch `Head(...)` construction still pass (the factory change is purely additive on unset-key reads). No new test is added because the repro is a straightforward standard-library semantic; happy to add an explicit regression test if reviewers would prefer.