### PR TITLE
fix(security): bound categorical cardinality before embedding allocation (T4R-006)

### DIFF
--- a/merlin_standard_lib/schema/schema.py
+++ b/merlin_standard_lib/schema/schema.py
@@ -538,13 +538,43 @@ def _proto_text_to_better_proto(
     return better_proto_message.__class__().from_json(json_str)
 
 
-def categorical_cardinalities(schema) -> Dict[str, int]:
-    if isinstance(schema, CoreSchema):
-        return mm_schema_utils.categorical_cardinalities(schema)
+# Default ~10M embeddings; override via env for large-catalog deployments.
+_MAX_CATEGORICAL_CARDINALITY = int(
+    os.environ.get("T4REC_MAX_CATEGORICAL_CARDINALITY", "10000000")
+)
 
-    outputs = {}
-    for col in schema:
-        if col.int_domain and col.int_domain.is_categorical:
-            outputs[col.name] = col.int_domain.max + 1
 
+def get_max_categorical_cardinality(max_cardinality: Optional[int] = None) -> int:
+    if max_cardinality is not None:
+        return max_cardinality
+    return _MAX_CATEGORICAL_CARDINALITY
+
+
+def _validate_categorical_cardinalities(
+    outputs: Dict[str, int], limit: int
+) -> Dict[str, int]:
+    for name, card in outputs.items():
+        if card < 1:
+            raise ValueError(f"Invalid cardinality for {name!r}: {card}")
+        if card > limit:
+            raise ValueError(
+                f"Categorical cardinality for {name!r} is {card}, which exceeds "
+                f"max_cardinality={limit}. Raise T4REC_MAX_CATEGORICAL_CARDINALITY "
+                f"or pass max_cardinality= if this catalog size is intentional."
+            )
     return outputs
+
+
+def categorical_cardinalities(
+    schema, max_cardinality: Optional[int] = None
+) -> Dict[str, int]:
+    if isinstance(schema, CoreSchema):
+        outputs = mm_schema_utils.categorical_cardinalities(schema)
+    else:
+        outputs = {}
+        for col in schema:
+            if col.int_domain and col.int_domain.is_categorical:
+                outputs[col.name] = col.int_domain.max + 1
+
+    limit = get_max_categorical_cardinality(max_cardinality)
+    return _validate_categorical_cardinalities(outputs, limit)

--- a/tests/unit/merlin_standard_lib/schema/test_schema.py
+++ b/tests/unit/merlin_standard_lib/schema/test_schema.py
@@ -64,6 +64,19 @@ def test_column_schema_categorical_with_shape():
     assert categorical_cardinalities(schema.Schema([col])) == dict(cat_1=1000 + 1)
 
 
+def test_categorical_cardinalities_rejects_oversized_schema():
+    col = schema.ColumnSchema.create_categorical("huge_cat", 10**9 - 1)
+    with pytest.raises(ValueError, match="exceeds max_cardinality"):
+        categorical_cardinalities(schema.Schema([col]))
+
+
+def test_categorical_cardinalities_respects_max_cardinality_override():
+    col = schema.ColumnSchema.create_categorical("huge_cat", 10**9 - 1)
+    assert categorical_cardinalities(schema.Schema([col]), max_cardinality=10**12) == {
+        "huge_cat": 10**9
+    }
+
+
 def test_column_schema_categorical_with_value_count():
     col = schema.ColumnSchema.create_categorical(
         "cat_1", 1000, value_count=schema.ValueCount(0, 100)

--- a/transformers4rec/torch/features/embedding.py
+++ b/transformers4rec/torch/features/embedding.py
@@ -22,6 +22,7 @@ from merlin.models.utils.doc_utils import docstring_parameter
 from merlin.schema import Tags, TagsType
 
 from merlin_standard_lib import Schema, categorical_cardinalities
+from merlin_standard_lib.schema.schema import get_max_categorical_cardinality
 from merlin_standard_lib.utils.embedding_utils import get_embedding_sizes_from_schema
 
 from ..block.base import SequentialBlock
@@ -447,6 +448,13 @@ class TableConfig:
     ):
         if not isinstance(vocabulary_size, int) or vocabulary_size < 1:
             raise ValueError("Invalid vocabulary_size {}.".format(vocabulary_size))
+
+        max_vocab = get_max_categorical_cardinality()
+        if vocabulary_size > max_vocab:
+            raise ValueError(
+                f"vocabulary_size {vocabulary_size} exceeds max_cardinality={max_vocab}. "
+                "Raise T4REC_MAX_CATEGORICAL_CARDINALITY if this catalog size is intentional."
+            )
 
         if not isinstance(dim, int) or dim < 1:
             raise ValueError("Invalid dim {}.".format(dim))


### PR DESCRIPTION
## Summary
- Add a configurable ceiling (default **10M**, env `T4REC_MAX_CATEGORICAL_CARDINALITY`) to `categorical_cardinalities`, validating both local `Schema` and Merlin-core `CoreSchema` paths.
- Fail closed with `ValueError` when a categorical feature's vocabulary size exceeds the limit, blocking pathological `int_domain.max` values from reaching `torch.nn.Embedding` allocation.
- Add the same upper bound in `TableConfig.__init__` for defense in depth.
- Regression tests for rejection and `max_cardinality=` override.

## Motivation
Untrusted schema input could set `int_domain.max` to very large values; `categorical_cardinalities()` previously returned `max + 1` with no bound, leading to multi‑TB embedding table requests and OOM at model build time (finding **T4R-006** / CWE-789).

## Test plan
- [ ] `pytest tests/unit/config/test_schema.py tests/unit/merlin_standard_lib/schema/test_schema.py tests/unit/torch/features/test_embedding.py`
- [ ] New tests: oversized schema raises; override allows large intentional catalogs; existing ~52k yoochoose cardinalities unchanged