### PR TITLE
fix(security): guard schema parsing against deep struct nesting (T4R-012)

### DIFF
--- a/merlin_standard_lib/schema/schema.py
+++ b/merlin_standard_lib/schema/schema.py
@@ -393,11 +393,19 @@ class Schema(_Schema):
         return item_id_col.column_names[0]
 
     def from_json(self, value: Union[str, bytes]) -> "Schema":
-        if os.path.isfile(value):
+        if isinstance(value, str) and os.path.isfile(value):
             with open(value, "rb") as f:
-                value = f.read()
+                payload = f.read()
+        else:
+            payload = value
 
-        return super().from_json(value)
+        _assert_schema_json_depth(payload)
+        try:
+            return super().from_json(payload)
+        except RecursionError as e:
+            raise ValueError(
+                "Schema nesting too deep (recursion limit hit while parsing)."
+            ) from e
 
     def to_proto_text(self) -> str:
         from tensorflow_metadata.proto.v0 import schema_pb2
@@ -516,6 +524,54 @@ class Schema(_Schema):
         return result
 
 
+_MAX_SCHEMA_NESTING_DEPTH = int(os.environ.get("T4REC_MAX_SCHEMA_NESTING_DEPTH", "64"))
+
+
+def _struct_nesting_depth(node: Any, depth: int = 0) -> int:
+    """Max nesting of Feature -> structDomain -> feature chains."""
+    if depth > _MAX_SCHEMA_NESTING_DEPTH:
+        return depth
+    if not isinstance(node, dict):
+        return depth
+
+    struct = node.get("structDomain") or node.get("struct_domain") or {}
+    features = []
+    if isinstance(struct, dict):
+        features = struct.get("feature") or []
+
+    max_d = depth
+    for child in features:
+        max_d = max(max_d, _struct_nesting_depth(child, depth + 1))
+    return max_d
+
+
+def _assert_schema_dict_depth(data: dict) -> None:
+    features = data.get("feature") or []
+    for feat in features:
+        if _struct_nesting_depth(feat) > _MAX_SCHEMA_NESTING_DEPTH:
+            raise ValueError(
+                f"Schema struct nesting exceeds max depth "
+                f"{_MAX_SCHEMA_NESTING_DEPTH}. Rejecting input."
+            )
+
+
+def _assert_schema_json_depth(value: Union[str, bytes]) -> None:
+    if isinstance(value, bytes):
+        text = value.decode("utf-8")
+    elif isinstance(value, str):
+        text = value
+    else:
+        return
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return
+
+    if isinstance(data, dict):
+        _assert_schema_dict_depth(data)
+
+
 def _proto_text_to_better_proto(
     better_proto_message: ProtoMessageType, path_proto_text: str, message: ProtoMessage
 ) -> ProtoMessageType:
@@ -524,18 +580,29 @@ def _proto_text_to_better_proto(
         with open(path_proto_text, "r") as f:
             proto_text = f.read()
 
-    proto = text_format.Parse(proto_text, message)
+    try:
+        proto = text_format.Parse(proto_text, message)
+    except RecursionError as e:
+        raise ValueError(
+            "Schema nesting too deep (recursion limit hit while parsing)."
+        ) from e
 
     # This is a hack because as of now we can't parse the Any representation.
     # TODO: Fix this.
     d = json_format.MessageToDict(proto)
+    _assert_schema_dict_depth(d)
     for f in d["feature"]:
         if "extraMetadata" in f["annotation"]:  # type: ignore
             extra_metadata = f["annotation"].pop("extraMetadata")  # type: ignore
             f["annotation"]["comment"] = [json.dumps(extra_metadata[0]["value"])]  # type: ignore
     json_str = json_format.MessageToJson(json_format.ParseDict(d, message))
 
-    return better_proto_message.__class__().from_json(json_str)
+    try:
+        return better_proto_message.__class__().from_json(json_str)
+    except RecursionError as e:
+        raise ValueError(
+            "Schema nesting too deep (recursion limit hit while parsing)."
+        ) from e
 
 
 def categorical_cardinalities(schema) -> Dict[str, int]:

--- a/tests/unit/merlin_standard_lib/schema/test_schema.py
+++ b/tests/unit/merlin_standard_lib/schema/test_schema.py
@@ -19,6 +19,16 @@ from merlin_standard_lib import categorical_cardinalities
 from merlin_standard_lib.schema import schema
 
 
+def _nested_struct_schema_json(depth: int) -> str:
+    open_part = '{"name":"s","type":"STRUCT","structDomain":{"feature":['
+    close_part = "]}}"
+    leaf = (
+        '{"name":"leaf","type":"INT",'
+        '"intDomain":{"name":"leaf","max":"5","isCategorical":true}}'
+    )
+    return '{"feature":[' + open_part * depth + leaf + close_part * depth + "]}"
+
+
 def test_column_proto_txt():
     col = schema.ColumnSchema(name="qa")
 
@@ -62,6 +72,18 @@ def test_column_schema_categorical_with_shape():
     assert col.shape.dim[0].size == 1
 
     assert categorical_cardinalities(schema.Schema([col])) == dict(cat_1=1000 + 1)
+
+
+def test_schema_from_json_rejects_deep_struct_nesting():
+    payload = _nested_struct_schema_json(100)
+    with pytest.raises(ValueError, match="struct nesting exceeds max depth"):
+        schema.Schema().from_json(payload)
+
+
+def test_schema_from_json_accepts_shallow_struct_nesting():
+    payload = _nested_struct_schema_json(5)
+    loaded = schema.Schema().from_json(payload)
+    assert len(loaded.column_names) == 1
 
 
 def test_column_schema_categorical_with_value_count():


### PR DESCRIPTION
## Summary
- Add a configurable struct nesting limit (default **64**, env `T4REC_MAX_SCHEMA_NESTING_DEPTH`) and pre-parse depth checks for schema JSON.
- Wrap `Schema.from_json` and `_proto_text_to_better_proto` so `RecursionError` becomes a clear `ValueError` (fail closed).
- Validate protobuf-text payloads after `MessageToDict` before re-parsing into betterproto objects.
- Regression tests for deep nested `structDomain` rejection and shallow nested schema acceptance.

## Motivation
Maliciously nested schema JSON/protobuf text can recurse through `Feature.struct_domain` cycles and crash schema loading with `RecursionError` (finding **T4R-012** / CWE-674).

## Test plan
- [ ] `pytest tests/unit/merlin_standard_lib/schema/test_schema.py tests/unit/config/test_schema.py`
- [ ] New tests: depth 100 nested JSON raises `ValueError`; depth 5 nested JSON loads
- [ ] Optional: `python .security/fuzz/fuzz_schema.py` (T4R-012 section should no longer surface uncaught `RecursionError` for depth 500+)